### PR TITLE
Disable scalafmt on compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Compile and check format
-        run: sbt Test/compile scalafmtSbt && git diff --exit-code
+        run: sbt scalafmtCheckAll scalafmtSbtCheck && git diff --exit-code
 
       - name: Compile API documentation
         run: sbt doc

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,6 @@ lazy val root =
     .settings(
       name := "smockito",
       scalaVersion := Dependencies.Versions.scala,
-      scalafmtOnCompile := true,
       javaAgents := Seq(mockito % Test),
       scalacOptions ++=
         Seq(


### PR DESCRIPTION
This breaks some IDE integrations, such as IntelliJ+bsp.