### PR TITLE
Make Mock[T] a proper subtype of T

### DIFF
--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -12,7 +12,7 @@ import scala.util.Try
 
 /** A `Mock` represents a type mocked by Mockito. See [[Smockito.mock]] for more information.
   */
-opaque type Mock[T] = T
+opaque type Mock[T] <: T = T
 
 private[smockito] trait MockSyntax:
 
@@ -140,6 +140,3 @@ object Mock:
 
   private[smockito] def apply[T](using ct: ClassTag[T]): Mock[T] =
     Mockito.mock(ct.runtimeClass.asInstanceOf[Class[T]])
-
-  given [T]: Conversion[Mock[T], T] with
-    def apply(mock: Mock[T]): T = mock

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -4,6 +4,7 @@ import com.bdmendes.smockito.Smockito.SmockitoException.*
 import com.bdmendes.smockito.SmockitoSpec.*
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
+import scala.compiletime.summonFrom
 import scala.compiletime.testing.typeChecks
 
 class SmockitoSpec extends munit.FunSuite with Smockito:
@@ -40,6 +41,21 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     Mockito.verify(repository).exists(ArgumentMatchers.any)
 
     assertEquals(repository.calls(it.exists), List(Tuple1("pedronuno")))
+
+  test("be a subtype of T"):
+    inline def isSubtypeOf[A, B] =
+      summonFrom {
+        case _: (A <:< B) =>
+          true
+        case _ =>
+          false
+      }
+
+    assert(isSubtypeOf[Mock[User], User])
+    assert(isSubtypeOf[Mock[Repository[User]], Repository[User]])
+    assert(!isSubtypeOf[Mock[User], String])
+    assert(!isSubtypeOf[Mock[User], Repository[User]])
+    assert(!isSubtypeOf[Mock[Repository[User]], User])
 
   test("set up method stubs, on methods with 0 parameters"):
     val repository = mock[Repository[User]].on(() => it.get)(_ => mockUsers)


### PR DESCRIPTION
There is no need for the implicit conversion. This allows for more use cases.