### PR TITLE
Remove some README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,8 @@
 
 [![Build](https://img.shields.io/github/actions/workflow/status/bdmendes/smockito/ci.yml)](https://github.com/bdmendes/smockito/actions)
 [![Codecov](https://img.shields.io/codecov/c/github/bdmendes/smockito/master)](https://app.codecov.io/gh/bdmendes/smockito)
-[![Release](https://img.shields.io/github/v/release/bdmendes/smockito)](https://github.com/bdmendes/smockito/releases)
 [![Maven Central](https://img.shields.io/maven-central/v/com.bdmendes/smockito_3
 )](https://central.sonatype.com/artifact/com.bdmendes/smockito_3/overview)
-[![Javadoc](https://javadoc.io/badge2/com.bdmendes/smockito_3/javadoc.svg)](https://javadoc.io/doc/com.bdmendes/smockito_3)
 
 Smockito is a tiny framework-agnostic Scala 3 facade for [Mockito](https://github.com/mockito/mockito). It enables setting up unique method stubs for any type in a type-safe manner, while providing an expressive interface for inspecting received arguments and call counts.
 


### PR DESCRIPTION
Javadoc is taking a while to update; let's drop it and releases and just keep one version pointer.