### PR TITLE
Do not shorten spec in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Don't. Instead of clearing history on a global mock, create a fresh mock for eac
 If you are in the process of migrating from another mocking framework and stumble across Smockito's opinionated soundness verifications, you might be interested in disabling them via the trait constructor:
 
 ```scala
-trait MySpec extends Smockito(SmockitoMode.Relaxed)
+trait MySpecification extends Smockito(SmockitoMode.Relaxed)
 ```
 
 In the end, however, it's always best to define a unique stub and be explicit about behavior change. If you want to mock system state, keep things simple:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example naming to improve clarity and consistency (renamed example trait to a more descriptive name).
  * No functional, API, or behavioral changes; no action required for users.
  * Usage and configuration guidance remain unchanged; the example’s structure and intent are the same.
  * Aims to reduce confusion for new users by aligning example names with common conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->