### PR TITLE
Remove codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 <img src="./assets/logo.svg" width="125" height="125" align="right">
 
 [![Build](https://img.shields.io/github/actions/workflow/status/bdmendes/smockito/ci.yml)](https://github.com/bdmendes/smockito/actions)
-[![Codecov](https://img.shields.io/codecov/c/github/bdmendes/smockito/master)](https://app.codecov.io/gh/bdmendes/smockito)
 [![Maven Central](https://img.shields.io/maven-central/v/com.bdmendes/smockito_3)](https://central.sonatype.com/artifact/com.bdmendes/smockito_3/overview)
 
 Smockito is a tiny framework-agnostic Scala 3 facade for [Mockito](https://github.com/mockito/mockito). It enables setting up unique method and value stubs for any type in a type-safe manner, while providing an expressive interface for inspecting received arguments and call counts.


### PR DESCRIPTION
Unfortunately, Codecov has been very unreliable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed the Codecov coverage badge from the project README to reduce visual clutter and avoid displaying an external/outdated coverage indicator.
  * This is a documentation-only cleanup with no impact on features, behavior, builds, tests, or public APIs.
  * Improves landing-page readability and presentation for users and contributors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->