### PR TITLE
Use fewerBraces in scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -8,7 +8,7 @@ rewrite.rules = [Imports, AvoidInfix, RedundantParens]
 rewrite.imports.sort = ascii
 rewrite.imports.expand = true
 rewrite.scala3.convertToNewSyntax = true
-rewrite.scala3.removeOptionalBraces = true
+rewrite.scala3.removeOptionalBraces = {"enabled": true, "fewerBracesMinSpan": 1, "fewerBracesMaxSpan": 2147483647}
 comments.wrap = standalone
 comments.wrapStandaloneSlcAsSlc = true
 


### PR DESCRIPTION
It turns out scalafmt already implemented those

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Scala formatting rules to refine optional-brace handling, improving code consistency and readability across the codebase.

* **Chores**
  * Maintenance update to formatting configuration. No impact on runtime behavior or public APIs; no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->