### PR TITLE
Use a vertical scalafmt style for fewerBraces

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -8,7 +8,9 @@ rewrite.rules = [Imports, AvoidInfix, RedundantParens]
 rewrite.imports.sort = ascii
 rewrite.imports.expand = true
 rewrite.scala3.convertToNewSyntax = true
-rewrite.scala3.removeOptionalBraces = {"enabled": true, "fewerBracesMinSpan": 1, "fewerBracesMaxSpan": 2147483647}
+rewrite.scala3.removeOptionalBraces.enabled = true
+rewrite.scala3.removeOptionalBraces.fewerBracesMinSpan = 1
+rewrite.scala3.removeOptionalBraces.fewerBracesMaxSpan = 2147483647
 comments.wrap = standalone
 comments.wrapStandaloneSlcAsSlc = true
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized Scala formatter configuration by splitting a combined optional-braces setting into explicit keys.
  * Preserves existing behavior (no functional changes for users).
  * Improves clarity and maintainability of formatting rules and aligns with current tooling expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->