### PR TITLE
Remove relaxed mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Smockito leverages a subset of Mockito’s features and offers a minimal, opinio
 - A method should be stubbed only once, and use the same implementation for the lifetime of the mock.
 - A method stub should handle only the inputs it expects.
 - A method stub should always be executed, as the real method would.
-- One may reason directly about the received arguments and number of calls of a stub.
+- An unstubbed method will delegate to the real method.
 - One should not reason about the history of a method that was not stubbed.
 
 ## Quick Start
@@ -120,15 +120,9 @@ Notice we are handling partiality explicitly. This is useful if you don't want S
 
 Don't. Instead of clearing history on a global mock, create a fresh mock for each test case. This approach avoids race conditions entirely, with a negligible performance cost.
 
-### I need to override stubs or reason about unstubbed methods.
+### Should I override stubs to change behavior?
 
-If you are in the process of migrating from another mocking framework and stumble across Smockito's opinionated soundness verifications, you might be interested in disabling them via the trait constructor:
-
-```scala
-trait MySpecification extends Smockito(SmockitoMode.Relaxed)
-```
-
-In the end, however, it's always best to define a unique stub and be explicit about behavior change. If you want to mock system state, keep things simple:
+No. It's always best to define a unique stub and be explicit about behavior change. If you want to mock system state, keep things simple:
 
 ```scala
 val repository = 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Smockito leverages a subset of Mockito’s features and offers a minimal, opinio
 - A method stub should handle only the inputs it expects.
 - A method stub should always be executed, as the real method would.
 - An unstubbed method will delegate to the real method.
+- One should not reason about the history of a method that was not stubbed.
 
 ## Quick Start
 

--- a/src/main/scala/com/bdmendes/smockito/Smockito.scala
+++ b/src/main/scala/com/bdmendes/smockito/Smockito.scala
@@ -99,6 +99,13 @@ object Smockito:
             "or if one or more default parameters are being discarded."
         )
 
+    case object UnstubbedMethod
+        extends SmockitoException(
+          s"The received method was not stubbed, so you cannot reason about it. " +
+            "Are you performing eta-expansion correctly? " +
+            "Did you forget to set up the stub first?"
+        )
+
     case class RealMethodFailure(method: Method, throwable: Throwable)
         extends SmockitoException(
           s"${describeMethod(method)} was not stubbed and failed with:\n$throwable\n" +

--- a/src/main/scala/com/bdmendes/smockito/Smockito.scala
+++ b/src/main/scala/com/bdmendes/smockito/Smockito.scala
@@ -1,6 +1,5 @@
 package com.bdmendes.smockito
 
-import com.bdmendes.smockito.Smockito.SmockitoMode
 import java.lang.reflect.Method
 import scala.reflect.ClassTag
 
@@ -49,11 +48,8 @@ import scala.reflect.ClassTag
   * one only cares about the number of times a stub was called, [[times]] is more efficient.
   *
   * [[Mock]] is interoperable with all [[org.mockito.Mockito]] APIs.
-  *
-  * @param smockitoMode
-  *   The [[Smockito.SmockitoMode]] used.
   */
-trait Smockito(val smockitoMode: SmockitoMode = SmockitoMode.Strict) extends MockSyntax:
+trait Smockito extends MockSyntax:
 
   /** Creates a [[Mock]] instance of `T`.
     *
@@ -82,20 +78,6 @@ trait Smockito(val smockitoMode: SmockitoMode = SmockitoMode.Strict) extends Moc
 
 object Smockito:
 
-  /** Specifies whether to perform opinionated soundness verifications.
-    */
-  enum SmockitoMode:
-
-    /** In strict mode, Smockito performs soundness verifications of one's testing flow, namely
-      * overriding a method stub and reasoning about unstubbed methods.
-      */
-    case Strict
-
-    /** In relaxed mode, Smockito does not perform soundness verifications. This may be useful
-      * during migrations from other mocking frameworks.
-      */
-    case Relaxed
-
   private lazy val exceptionTrailer =
     s"Please review the documentation at https://github.com/bdmendes/smockito. " +
       "If you think this is a bug, please open an issue with a minimal reproducible example."
@@ -115,21 +97,6 @@ object Smockito:
             "Double-check if this method has contextual parameters and " +
             "they are inadvertently being captured in the spec scope, " +
             "or if one or more default parameters are being discarded."
-        )
-
-    case object UnstubbedMethod
-        extends SmockitoException(
-          s"The received method was not stubbed, so you cannot reason about it. " +
-            "Are you performing eta-expansion correctly? " +
-            "Did you forget to set up the stub first?"
-        )
-
-    case class AlreadyStubbedMethod(method: Method)
-        extends SmockitoException(
-          s"${describeMethod(method)} is already stubbed. " +
-            "If you need to perform a different action on a subsequent invocation, " +
-            "replace the mock or reflect that intent through a state lookup in the stub. " +
-            "If you really want to override the stub, disable strict mode."
         )
 
     case class RealMethodFailure(method: Method, throwable: Throwable)

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -1,7 +1,6 @@
 package com.bdmendes.smockito
 
 import com.bdmendes.smockito.Smockito.SmockitoException.*
-import com.bdmendes.smockito.Smockito.SmockitoMode
 import com.bdmendes.smockito.SmockitoSpec.*
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
@@ -335,24 +334,6 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     intercept[UnknownMethod.type]:
       val _ = mock[Repository[User]].on(it.greet)(_ => "hi!")
 
-  test("throw on reasoning on unstubbed methods"):
-    val repository = mock[Repository[User]].on(() => it.get)(_ => List.empty)
-
-    // We should not be able to reason about unstubbed methods.
-    intercept[UnstubbedMethod.type]:
-      repository.times(it.getWith)
-
-    intercept[UnstubbedMethod.type]:
-      repository.calls(it.getWith)
-
-    // Although we cannot be sure if there is a matching stub.
-    repository.times(() => it.getNames)
-
-    // Unstubbed method verification is disabled in relaxed mode.
-    new Smockito(SmockitoMode.Relaxed):
-      repository.times(it.getWith)
-      repository.calls(it.getWith)
-
   test("provide a forward sugar for spying on a real instance"):
     val repository =
       new Repository[User]("dummy"):
@@ -395,6 +376,7 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     // This method was not forwarded, so expect a real method call failure.
     intercept[RealMethodFailure]:
       val _ = mockRepository.get
+
     // One should not be able to reason about unstubbed methods, even in this forwarding scenario.
     intercept[UnstubbedMethod.type]:
       mockRepository.times(it.getWith)

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -429,13 +429,13 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     abstract class Getter:
       def getNames: List[String]
       def getNamesAdapter = getNames
-      def getNamesAdapterWithParam(dummy: String) = getNames
+      def getNamesAdapterWithParam(dummy: Int, a: Int) = getNames
 
     val names = mockUsers.map(_.username)
     val getter = mock[Getter].on(() => it.getNames)(_ => names)
 
     assertEquals(getter.getNamesAdapter, names)
-    assertEquals(getter.getNamesAdapterWithParam("dummy"), names)
+    assertEquals(getter.getNamesAdapterWithParam(1, 2), names)
 
     assertEquals(getter.times(() => it.getNames), 2)
 

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -334,6 +334,19 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     intercept[UnknownMethod.type]:
       val _ = mock[Repository[User]].on(it.greet)(_ => "hi!")
 
+  test("throw on reasoning on unstubbed methods"):
+    val repository = mock[Repository[User]].on(() => it.get)(_ => List.empty)
+
+    // We should not be able to reason about unstubbed methods.
+    intercept[UnstubbedMethod.type]:
+      repository.times(it.getWith)
+
+    intercept[UnstubbedMethod.type]:
+      repository.calls(it.getWith)
+
+    // Although we cannot be sure if there is a matching stub.
+    repository.times(() => it.getNames)
+
   test("provide a forward sugar for spying on a real instance"):
     val repository =
       new Repository[User]("dummy"):
@@ -429,13 +442,13 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     abstract class Getter:
       def getNames: List[String]
       def getNamesAdapter = getNames
-      def getNamesAdapterWithParam(dummy: Int, a: Int) = getNames
+      def getNamesAdapterWithParam(dummy: String) = getNames
 
     val names = mockUsers.map(_.username)
     val getter = mock[Getter].on(() => it.getNames)(_ => names)
 
     assertEquals(getter.getNamesAdapter, names)
-    assertEquals(getter.getNamesAdapterWithParam(1, 2), names)
+    assertEquals(getter.getNamesAdapterWithParam("dummy"), names)
 
     assertEquals(getter.times(() => it.getNames), 2)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Breaking Changes
  - Removed Strict/Relaxed modes and the SmockitoMode setting; Smockito no longer accepts a mode parameter.
  - Unstubbed calls now delegate to real methods; method existence and “stubbed-before” checks are always enforced.
  - Removed the AlreadyStubbedMethod error type.
- Documentation
  - Updated guidance to favor explicit, unique stubs (with a factory-style pattern) and clarified behavior of unstubbed methods.
  - Revised Quick Start and retitled sections to reflect the new approach.
- Tests
  - Removed relaxed-mode test paths and related imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->