### PR TITLE
Remove unstubbed verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ def mockRepository(username: String): Mock[Repository[User]] =
 
 ### What happens if I call an unstubbed method?
 
-An unstubbed method call will delegate to the real method implementation, instead of returning the default, lenient sentinel values of Mockito. This allows one to stub a method at the bottom the hierarchy, and interact with its adapters for free:
+An unstubbed method call will delegate to the real method implementation, instead of returning a lenient sentinel value. This allows one to stub a method at the bottom the hierarchy, and interact with its adapters for free:
 
 ```scala
 trait Getter:
@@ -152,8 +152,8 @@ trait Getter:
 
 val getter = mock[Getter].on(() => it.getNames)(_ => List("john"))
 
-assertEquals(getter.getNamesAdapter("dummy"), List("john"))
-assertEquals(getter.times(() => it.getNames), 1)
+assert(getter.getNamesAdapter("dummy") == List("john"))
+assert(getter.times(() => it.getNames) == 1)
 ```
 
 That said, if the real method requires some class context, it will throw. Stub all methods that are not simple adapters.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Smockito leverages a subset of Mockito’s features and offers a minimal, opinio
 - A method stub should handle only the inputs it expects.
 - A method stub should always be executed, as the real method would.
 - An unstubbed method will delegate to the real method.
-- One should not reason about the history of a method that was not stubbed.
 
 ## Quick Start
 

--- a/src/main/scala/com/bdmendes/smockito/Smockito.scala
+++ b/src/main/scala/com/bdmendes/smockito/Smockito.scala
@@ -99,13 +99,6 @@ object Smockito:
             "or if one or more default parameters are being discarded."
         )
 
-    case object UnstubbedMethod
-        extends SmockitoException(
-          s"The received method was not stubbed, so you cannot reason about it. " +
-            "Are you performing eta-expansion correctly? " +
-            "Did you forget to set up the stub first?"
-        )
-
     case class RealMethodFailure(method: Method, throwable: Throwable)
         extends SmockitoException(
           s"${describeMethod(method)} was not stubbed and failed with:\n$throwable\n" +

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -334,19 +334,6 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     intercept[UnknownMethod.type]:
       val _ = mock[Repository[User]].on(it.greet)(_ => "hi!")
 
-  test("throw on reasoning on unstubbed methods"):
-    val repository = mock[Repository[User]].on(() => it.get)(_ => List.empty)
-
-    // We should not be able to reason about unstubbed methods.
-    intercept[UnstubbedMethod.type]:
-      repository.times(it.getWith)
-
-    intercept[UnstubbedMethod.type]:
-      repository.calls(it.getWith)
-
-    // Although we cannot be sure if there is a matching stub.
-    repository.times(() => it.getNames)
-
   test("provide a forward sugar for spying on a real instance"):
     val repository =
       new Repository[User]("dummy"):
@@ -389,10 +376,6 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     // This method was not forwarded, so expect a real method call failure.
     intercept[RealMethodFailure]:
       val _ = mockRepository.get
-
-    // One should not be able to reason about unstubbed methods, even in this forwarding scenario.
-    intercept[UnstubbedMethod.type]:
-      mockRepository.times(it.getWith)
 
   test("integrate with an effects system"):
     given ExecutionContext = ExecutionContext.global


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified method validation before stubbing/counting; unsupported calls now consistently report UnknownMethod.
  * Removed UnstubbedMethod from the public API.

* **Documentation**
  * Modernized wording and examples for unstubbed methods.
  * Updated assertion style in examples to current syntax.

* **Tests**
  * Removed assertions expecting UnstubbedMethod and aligned tests with the new validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->