### PR TITLE
Fix handling of class-dependant default parameters

### DIFF
--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -164,6 +164,8 @@ private object Mock:
           try
             invocation.callRealMethod()
           catch
+            case _ if invocation.getMethod.getName.contains("$default$") =>
+              Mockito.RETURNS_DEFAULTS.answer(invocation)
             case _: MockitoException =>
               throw RealMethodFailure(
                 invocation.getMethod,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mocks now return sensible default values for methods generated for default parameters, avoiding unexpected failures and improving compatibility with Scala default-argument and interface default methods.
  * More predictable behavior when stubbing or forwarding calls that rely on defaulted parameters.

* **Tests**
  * Added scenarios covering repositories with default arguments and verification of behavior with both class-dependent and free defaults.
  * Extended stubbing and forwarding tests to include methods using default parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->