### PR TITLE
Swallow real method failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ def mockRepository(username: String): Mock[Repository[User]] =
 
 ### What happens if I call an unstubbed method?
 
-An unstubbed method call will delegate to the real method implementation, instead of returning a lenient sentinel value. This allows one to stub a method at the bottom the hierarchy, and interact with its adapters for free:
+An unstubbed method call will delegate to the real method implementation, instead of returning a lenient sentinel value. This allows one to stub a method at the bottom of the hierarchy, and interact with its adapters for free:
 
 ```scala
 trait Getter:
@@ -156,7 +156,7 @@ assert(getter.getNamesAdapter("dummy") == List("john"))
 assert(getter.times(() => it.getNames) == 1)
 ```
 
-That said, if the real method requires some class context, it will throw. Stub all methods that are not simple adapters.
+That said, if the real method requires some class context, it will fail, and Smockito will answer with `null`. Stub all methods expected to be called that are not simple adapters.
 
 ### I need to assert invocation orders/X/Y/Z.
 

--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -10,6 +10,7 @@ import scala.compiletime.*
 import scala.jdk.CollectionConverters.*
 import scala.reflect.ClassTag
 import scala.util.Try
+import scala.util.control.NonFatal
 
 /** A `Mock` represents a type mocked by Mockito. See [[Smockito.mock]] for more information.
   */
@@ -164,6 +165,9 @@ private object Mock:
           // at the bottom of the hierarchy and preserving its adapters. It's also essential to
           // handle Scala default parameters, which are synthesized as a method. Here we swallow the
           // exception to be less annoying, and return null to signal failed computation.
-          try invocation.callRealMethod()
-          catch _ => null
+          try
+            invocation.callRealMethod()
+          catch
+            case NonFatal(_) =>
+              null
     )

--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -5,7 +5,6 @@ import com.bdmendes.smockito.Smockito.SmockitoException.*
 import com.bdmendes.smockito.internal.meta.*
 import java.lang.reflect.Method
 import org.mockito.*
-import org.mockito.exceptions.base.MockitoException
 import org.mockito.stubbing.Answer
 import scala.compiletime.*
 import scala.jdk.CollectionConverters.*
@@ -161,14 +160,10 @@ private object Mock:
       Mockito
         .withSettings()
         .defaultAnswer: invocation =>
-          try
-            invocation.callRealMethod()
-          catch
-            case _: MockitoException =>
-              throw RealMethodFailure(
-                invocation.getMethod,
-                IllegalStateException("Abstract method call")
-              )
-            case e =>
-              throw RealMethodFailure(invocation.getMethod, e)
+          // Calling the real method by default allows for more use cases, such as stubbing a method
+          // at the bottom of the hierarchy and preserving its adapters. It's also essential to
+          // handle Scala default parameters, which are synthesized as a method. Here we swallow the
+          // exception to be less annoying, and return null to signal failed computation.
+          try invocation.callRealMethod()
+          catch _ => null
     )

--- a/src/main/scala/com/bdmendes/smockito/Smockito.scala
+++ b/src/main/scala/com/bdmendes/smockito/Smockito.scala
@@ -99,12 +99,6 @@ object Smockito:
             "or if one or more default parameters are being discarded."
         )
 
-    case class RealMethodFailure(method: Method, throwable: Throwable)
-        extends SmockitoException(
-          s"${describeMethod(method)} was not stubbed and failed with:\n$throwable\n" +
-            "Did you forget to set up a stub for it? Was it called unexpectedly?"
-        )
-
     case class UnexpectedArguments(method: Method, arguments: Array[Object])
         extends SmockitoException(
           s"${describeMethod(method)} received unexpected arguments: " +

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -152,9 +152,7 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     val repository = mock[Repository[User]].on(it.contains(_: String))(_ => true)
 
     assert(repository.contains("bdmendes"))
-
-    intercept[RealMethodFailure]:
-      val _ = repository.contains(mockUsers.head)
+    assert(!repository.contains(mockUsers.head))
 
   test("disallow inspecting calls on values"):
     val repository = mock[Repository[String]].on(() => it.longName)(_ => "database")
@@ -219,9 +217,7 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
 
     val _ = repository.contains("bdmendes")
 
-    intercept[RealMethodFailure]:
-      val _ = repository.contains(mockUsers.head)
-
+    assert(!repository.contains(mockUsers.head))
     assertEquals(repository.calls(it.contains(_: String)), List("bdmendes"))
 
   test("inspect calls on methods with default arguments"):
@@ -316,9 +312,7 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
 
     val _ = repository.contains("bdmendes")
 
-    intercept[RealMethodFailure]:
-      val _ = repository.contains(mockUsers.head)
-
+    assert(!repository.contains(mockUsers.head))
     assertEquals(repository.times(it.contains(_: String)), 1)
 
   test("throw on unknown received method"):
@@ -374,8 +368,7 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     assertEquals(mockRepository.times(it.exists), 2)
 
     // This method was not forwarded, so expect a real method call failure.
-    intercept[RealMethodFailure]:
-      val _ = mockRepository.get
+    assertEquals(mockRepository.get, null)
 
   test("integrate with an effects system"):
     given ExecutionContext = ExecutionContext.global
@@ -453,15 +446,6 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
 
     val _ = getter.on(() => it.get)(_ => List.empty)
     assertEquals(tracker, 0)
-
-  test("fail when the real method touches a class variable"):
-    class Getter(name: String):
-      def length = name.length
-
-    val getter = mock[Getter]
-
-    intercept[RealMethodFailure]:
-      val _ = getter.length
 
 object SmockitoSpec:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Unstubbed method calls no longer throw errors; they now return default values (e.g., null/false), improving stability across overloaded methods and spy/forwarding scenarios.

- Documentation
  - Clarified behavior for unstubbed methods, updated guidance on which calls to stub, and fixed grammar.

- Tests
  - Updated expectations to reflect default return values for unstubbed calls and removed obsolete failure-based tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->