### PR TITLE
Default to throwing on unstubbed methods

### DIFF
--- a/src/main/scala/com/bdmendes/smockito/DefaultAnswer.scala
+++ b/src/main/scala/com/bdmendes/smockito/DefaultAnswer.scala
@@ -1,0 +1,16 @@
+package com.bdmendes.smockito
+
+import com.bdmendes.smockito.Smockito.SmockitoException.UnstubbedMethod
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+
+class DefaultAnswer extends Answer[Any]:
+
+  override def answer(invocation: InvocationOnMock): Any =
+    val method = invocation.getMethod
+    if method.getName.contains("$default$") then
+      // The Scala compiler synthesizes default arguments as methods.
+      try invocation.callRealMethod()
+      catch _ => null
+    else
+      throw UnstubbedMethod(method, invocation.getRawArguments)

--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -5,7 +5,6 @@ import com.bdmendes.smockito.Smockito.SmockitoException.*
 import com.bdmendes.smockito.internal.meta.*
 import java.lang.reflect.Method
 import org.mockito.*
-import org.mockito.exceptions.base.MockitoException
 import org.mockito.stubbing.Answer
 import scala.compiletime.*
 import scala.jdk.CollectionConverters.*
@@ -158,17 +157,5 @@ private object Mock:
   def apply[T](using ct: ClassTag[T]): Mock[T] =
     Mockito.mock(
       ct.runtimeClass.asInstanceOf[Class[T]],
-      Mockito
-        .withSettings()
-        .defaultAnswer: invocation =>
-          // Calling the real method by default allows for more use cases, such as stubbing a method
-          // at the bottom of the hierarchy and preserving its adapters. It's also essential to
-          // handle Scala default parameters, which are synthesized as a method.
-          try
-            invocation.callRealMethod()
-          catch
-            case _: NullPointerException | _: MockitoException =>
-              // The method touched a class value or is abstract. We swallow the exception to be
-              // less annoying, and return `null` to signal a failed computation.
-              null
+      Mockito.withSettings().defaultAnswer(DefaultAnswer())
     )

--- a/src/main/scala/com/bdmendes/smockito/Smockito.scala
+++ b/src/main/scala/com/bdmendes/smockito/Smockito.scala
@@ -104,3 +104,10 @@ object Smockito:
           s"${describeMethod(method)} received unexpected arguments: " +
             s"(${arguments.mkString(", ")}). " + "Did you forget to handle this case at the stub?"
         )
+
+    case class UnstubbedMethod(method: Method, arguments: Array[Object])
+        extends SmockitoException(
+          s"${describeMethod(method)} is not stubbed " +
+            s"and was called with arguments: (${arguments.mkString(", ")}). " +
+            "Did you forget to stub the method, or was it called unexpectedly?"
+        )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unstubbed method calls now throw a clear UnstubbedMethod error instead of delegating silently.
  - Improved handling of Scala default arguments to call real implementations when appropriate.
  - Documented a new pattern to dispatch to real implementations via a .real(adapter) chain for specific cases.

- Documentation
  - Updated README with the new unstubbed-method behavior, real-dispatch usage examples, and removed outdated caveats.
  - Refreshed code samples and formatting for clarity.

- Tests
  - Updated test suite to reflect the new explicit error behavior and expanded stubbing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->