### PR TITLE
Add `onCall` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ No. It's always best to define a unique stub and be explicit about behavior chan
 
 ```scala
 val repository = 
-  mock[Repository[User]].onCall(() => it.get): _ =>
+  mock[Repository[User]].onCall(() => it.get):
     case 1 => List(User("john"))
     case _ => List.empty
 ```

--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -172,11 +172,11 @@ private trait MockSyntax:
       * @return
       *   the mocked type.
       */
-    inline def onCall[A <: Tuple, R](method: Mock[T] ?=> MockedMethod[A, R])(
-        stub: Int => R
+    inline def onCall[A <: Tuple, R1, R2 <: R1](method: Mock[T] ?=> MockedMethod[A, R1])(
+        stub: Int => R2
     ): Mock[T] =
       var callCount = 0
-      val f: Pack[A] => R =
+      val f: Pack[A] => R2 =
         _ =>
           callCount += 1
           stub(callCount)

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -537,13 +537,16 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     assertEquals(tracker, 1)
     assertEquals(repository.times(() => it.get), 1)
 
-  test("provide a onCall sugar that tracks invocation counts"):
+  test("provide an onCall sugar that tracks invocation counts"):
     val repository =
       mock[Repository[User]].onCall(() => it.get):
         case 1 =>
           List(mockUsers.head)
         case _ =>
           List.empty
+
+    assert(typeChecks("repository.onCall(() => it.get)(_ => List.empty)"))
+    assert(!typeChecks("repository.onCall(() => it.get)(_ => 1)"))
 
     assertEquals(repository.get, List(mockUsers.head))
     assertEquals(repository.get, List.empty)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added onCall to define per-invocation behavior, allowing different return values across successive calls and tracking invocation counts.

* **Documentation**
  * Clarified doc wording to state stubs are based on received arguments.
  * Updated examples to show onCall usage replacing mutable-counter patterns.

* **Tests**
  * Added tests for onCall: unknown-method handling, no side effects when unattached, per-invocation dispatch, and invocation counting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->