### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ Description.
 **Full Changelog**: https://github.com/bdmendes/smockito/compare/<prev>...<this>
 -->
 
+## 2.1.0 - 2025-08-24
+
+This feature release adds a `onCall` convenience method to set up a stub that receives the call number instead of the method arguments, which might be useful when simulating transient failures. Besides this, there are new methods for reasoning about invocation orders on a mock - `calledBefore` and `calledAfter`.
+
+### What's Changed
+* Add `onCall` method by @bdmendes in https://github.com/bdmendes/smockito/pull/92
+* Add `calledBefore` method by @bdmendes in https://github.com/bdmendes/smockito/pull/93
+
+**Full Changelog**: https://github.com/bdmendes/smockito/compare/v2.0.0...v2.1.0
+
 ## 2.0.0 - 2025-08-22
 
 Smockito has been stable for a couple of weeks, benefiting from real-world usage and several bug fixes since 1.0. Now, it’s ready for an API update, a change significant enough to justify a major version bump.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Description.
 
 ## 2.1.0 - 2025-08-24
 
-This feature release adds a `onCall` convenience method to set up a stub that receives the call number instead of the method arguments, which might be useful when simulating transient failures. Besides this, there are new methods for reasoning about invocation orders on a mock - `calledBefore` and `calledAfter`.
+This feature release adds an `onCall` convenience method to set up a stub that receives the call number instead of the method arguments, which might be useful when simulating transient failures. Besides this, there are new methods for reasoning about invocation orders on a mock — `calledBefore` and `calledAfter`.
 
 ### What's Changed
 * Add `onCall` method by @bdmendes in https://github.com/bdmendes/smockito/pull/92

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Don't. Instead of clearing history on a global mock, create a fresh mock for eac
 
 ### Should I override stubs to change behavior?
 
-No. It's always best to define a unique stub and be explicit about behavior change. If you want to perform a different action on a subsequent invocation, consider using `onCall`:
+No. It's always best to define a unique stub and be explicit about behavior change. If you want to perform a different action on a subsequent invocation, for instance to simulate transient failures, consider using `onCall`:
 
 ```scala
 val repository = 

--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -218,7 +218,7 @@ private trait MockSyntax:
       * @param b
       *   the method that is expected to be called first.
       * @return
-      *   Whether `b` was called after `a`.
+      *   Whether `a` was called after `b`.
       */
     inline def calledAfter[A1 <: Tuple, R1, A2 <: Tuple, R2](
         a: Mock[T] ?=> MockedMethod[A1, R1],

--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -170,7 +170,7 @@ private trait MockSyntax:
       * @param method
       *   the method to mock.
       * @param stub
-      *   the stub implementation, based on the call number, starting at 1.
+      *   the stub implementation, based on the call number of the respective method, starting at 1.
       * @return
       *   the mocked type.
       */

--- a/src/main/scala/com/bdmendes/smockito/Smockito.scala
+++ b/src/main/scala/com/bdmendes/smockito/Smockito.scala
@@ -39,8 +39,8 @@ import scala.reflect.ClassTag
   *
   * Method stubs are set up with [[on]]. Besides the method to mock, it requires a
   * [[PartialFunction]] to handle the expected inputs, well-typed with the same shape as the mocked
-  * method arguments, that one may destructure. If you want to operate on the call number instead of
-  * the received arguments, use [[onCall]].
+  * method arguments, that one may destructure. If one needs to operate on the call number instead
+  * of the received arguments, [[onCall]] is an alternative.
   *
   * For spying on a real instance, use [[forward]]. For dispatching to a real implementation, use
   * [[real]].
@@ -48,7 +48,7 @@ import scala.reflect.ClassTag
   * [[calls]] provides the captured arguments of all the past invocations of a stubbed method, in
   * chronological order, packed with the same shape as the method arguments, à la `scalamock`. If
   * one only cares about the number of times a stub was called, [[times]] is more efficient. At
-  * last, [[calledBefore]] and [[calledAfter]] allows reasoning about interaction orders.
+  * last, [[calledBefore]] and [[calledAfter]] allow reasoning about interaction orders.
   */
 trait Smockito extends MockSyntax:
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.1.0"
+ThisBuild / version := "2.1.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.0.1-SNAPSHOT"
+ThisBuild / version := "2.1.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added 2.1.0 changelog entry highlighting onCall (call-number–based stubbing) and calledBefore/calledAfter (invocation ordering).
  - Clarified README guidance with an example scenario and refined API descriptions; improved grammar and phrasing in inline docs.
  - No functional or public API changes in this update.
- Chores
  - Updated Full Changelog link to compare v2.0.0...v2.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->