### PR TITLE
Require function in `onCall`

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ No. It's always best to define a unique stub and be explicit about behavior chan
 
 ```scala
 val repository = 
-  mock[Repository[User]].onCall(() => it.get):
-    case 1 => List(User("john"))
-    case _ => List.empty
+  mock[Repository[User]].onCall(it.exists):
+    case 1 | 2 => _ == "johndoe"
+    case _ => _ => false
 ```
 
 If you have a mock whose setup is only slightly changed between test cases, instead of overriding a stub defined in some base trait, create a factory method:

--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -37,8 +37,7 @@ private trait MockSyntax:
       if matching[A, R](methods).isEmpty then
         throw UnknownMethod
 
-    /** Sets up a stub for a method, based on the received tupled arguments. For the version based
-      * on the call number, see [[onCall]].
+    /** Sets up a stub for a method, based on the received tupled arguments.
       *
       * @param method
       *   the method to mock.
@@ -165,8 +164,8 @@ private trait MockSyntax:
       val realMethod = method(using realInstance.asInstanceOf[Mock[T]]).packed
       mock.on(method)(PartialFunctionProxy(realMethod))
 
-    /** Sets up a stub for a method, based on the call number. For the version based on received
-      * arguments, see [[on]].
+    /** Sets up a stub for a method that behaves differently based on the call number. For the
+      * version operating only on the expected set of inputs, see [[on]].
       *
       * @param method
       *   the method to mock.
@@ -176,10 +175,10 @@ private trait MockSyntax:
       *   the mocked type.
       */
     inline def onCall[A <: Tuple, R1, R2 <: R1](method: Mock[T] ?=> MockedMethod[A, R1])(
-        stub: Int => R2
+        stub: Int => Pack[A] => R2
     ): Mock[T] =
       val callCount = AtomicInteger(0)
-      val f = (_: Pack[A]) => stub(callCount.incrementAndGet())
+      val f = (args: Pack[A]) => stub(callCount.incrementAndGet())(args)
       mock.on(method)(PartialFunctionProxy(f))
 
     /** Whether the last invocation of method `a` happened before the last invocation of method `b`,

--- a/src/main/scala/com/bdmendes/smockito/Smockito.scala
+++ b/src/main/scala/com/bdmendes/smockito/Smockito.scala
@@ -39,8 +39,8 @@ import scala.reflect.ClassTag
   *
   * Method stubs are set up with [[on]]. Besides the method to mock, it requires a
   * [[PartialFunction]] to handle the expected inputs, well-typed with the same shape as the mocked
-  * method arguments, that one may destructure. If one needs to operate on the call number instead
-  * of the received arguments, [[onCall]] is an alternative.
+  * method arguments, that one may destructure. If one needs to provide a different implementation
+  * based on the call number, [[onCall]] is an alternative.
   *
   * For spying on a real instance, use [[forward]]. For dispatching to a real implementation, use
   * [[real]].

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -578,7 +578,7 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     assertEquals(repository.times(() => it.get), 3)
 
     assertEquals(repository.exists("bdmendes"), true)
-    assertEquals(repository.exists("johdone"), false)
+    assertEquals(repository.exists("johndoe"), false)
     assertEquals(repository.exists("bdmendes"), false)
     assertEquals(repository.times(it.exists), 3)
 

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -360,7 +360,7 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
       val _ = mock[Repository[User]].forward(merge, null)
 
     intercept[UnknownMethod.type]:
-      val _ = mock[Repository[User]].onCall(merge)(_ => mockUsers.head)
+      val _ = mock[Repository[User]].onCall(merge)(_ => _ => mockUsers.head)
 
     intercept[UnknownMethod.type]:
       val _ = mock[Repository[User]].real(merge)
@@ -555,22 +555,22 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     assertEquals(tracker, 1)
     assertEquals(repository.times(() => it.get), 1)
 
-  test("provide an onCall sugar that tracks invocation counts"):
+  test("provide an onCall sugar to change behavior based on call number"):
     val repository =
       mock[Repository[User]]
         .onCall(() => it.get):
           case 1 =>
-            List(mockUsers.head)
+            _ => List(mockUsers.head)
           case _ =>
-            List.empty
+            _ => List.empty
         .onCall(it.exists):
-          case 1 =>
-            true
+          case 1 | 2 =>
+            _ == "bdmendes"
           case _ =>
-            false
+            _ => false
 
-    assert(typeChecks("repository.onCall(() => it.get)(_ => List.empty)"))
-    assert(!typeChecks("repository.onCall(() => it.get)(_ => 1)"))
+    assert(typeChecks("repository.onCall(() => it.get)(_ => _ => List.empty)"))
+    assert(!typeChecks("repository.onCall(() => it.get)(_ => _ => 1)"))
 
     assertEquals(repository.get, List(mockUsers.head))
     assertEquals(repository.get, List.empty)
@@ -578,8 +578,9 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     assertEquals(repository.times(() => it.get), 3)
 
     assertEquals(repository.exists("bdmendes"), true)
+    assertEquals(repository.exists("johdone"), false)
     assertEquals(repository.exists("bdmendes"), false)
-    assertEquals(repository.times(it.exists), 2)
+    assertEquals(repository.times(it.exists), 3)
 
   test("reason about invocation orders"):
     val repository =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - onCall now supports argument-aware stubs, enabling behavior that varies by both invocation count and method arguments.
- Breaking Changes
  - onCall stubs must now return a function that accepts the method’s arguments; existing stubs may need wrapping to match the new shape.
- Documentation
  - README examples and docs updated to illustrate the revised onCall usage and behavior.
- Tests
  - Test suite updated to reflect and validate the new onCall semantics and invocation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->