### PR TITLE
Release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ Description.
 **Full Changelog**: https://github.com/bdmendes/smockito/compare/<prev>...<this>
 -->
 
+## 2.2.0 - 2025-08-24
+
+This release changes the `onCall` signature to require a `Int => Pack[A] => R` instead of a `Int => R`. This should enable more use cases and discourage the liberal usage of it instead of `on`.
+
+### What's Changed
+* Use AtomicInteger on onCall by @bdmendes in https://github.com/bdmendes/smockito/pull/97
+* Require function in `onCall` by @bdmendes in https://github.com/bdmendes/smockito/pull/98
+
+**Full Changelog**: https://github.com/bdmendes/smockito/compare/v2.1.0...v2.2.0
+
 ## 2.1.0 - 2025-08-24
 
 This feature release adds an `onCall` convenience method to set up a stub that receives the call number instead of the method arguments, which might be useful when simulating transient failures. Besides this, there are new methods for reasoning about invocation orders on a mock — `calledBefore` and `calledAfter`.

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.2.0"
+ThisBuild / version := "2.2.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.1.1-SNAPSHOT"
+ThisBuild / version := "2.2.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Updated onCall API to use a new function signature: Int => Pack[A] => R.
  - Passing a function to onCall is now mandatory.

- Documentation
  - Updated changelog for version 2.2.0 to reflect the onCall API changes.
  - Retained 2.1.0 notes for context on existing onCall-related features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->