### PR TITLE
Catch specific exception on call orders

### DIFF
--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -6,6 +6,7 @@ import com.bdmendes.smockito.internal.meta.*
 import java.lang.reflect.Method
 import java.util.concurrent.atomic.AtomicInteger
 import org.mockito.*
+import org.mockito.exceptions.base.MockitoAssertionError
 import org.mockito.stubbing.Answer
 import scala.compiletime.*
 import scala.jdk.CollectionConverters.*
@@ -198,14 +199,17 @@ private trait MockSyntax:
       assertMethodExists[A1, R1]()
       assertMethodExists[A2, R2]()
       val ordered = Mockito.inOrder(mock)
-      Try:
+      try
         a(using ordered.verify(mock, Mockito.atLeastOnce)).tupled(
           Tuple.fromArray(mapTuple[A1, Any](anyMatcher)).asInstanceOf[A1]
         )
         b(using ordered.verify(mock, Mockito.atLeastOnce)).tupled(
           Tuple.fromArray(mapTuple[A2, Any](anyMatcher)).asInstanceOf[A2]
         )
-      .isSuccess
+        true
+      catch
+        case _: MockitoAssertionError =>
+          false
 
     /** Whether the last invocation of method `a` happened after the last invocation of method `b`,
       * provided both methods were called at least once. Same as `calledBefore(b, a)`.


### PR DESCRIPTION
Should prevent rare but possible invalid method type clashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call-order verification to treat only assertion failures as expected outcomes, preventing unrelated exceptions from being swallowed.
  * Reduces false negatives in verification results and surfaces unexpected errors for clearer diagnostics.
  * Enhances reliability and accuracy of test feedback without changing the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->