### PR TITLE
Allow self-references in stubs

### DIFF
--- a/docs/_docs/guide.md
+++ b/docs/_docs/guide.md
@@ -18,7 +18,7 @@ val filter = Mockito.mock(classOf[Filter], DefaultThrowAnswer)
 val answer =
   (invocation: InvocationOnMock) =>
     val args = invocation.getRawArguments.asInstanceOf[Int => Boolean]
-    stub(args) // in this case, stub is (_ => List(1, 2, 3))
+    stub(using filter)(args) // in this case, stub is (_ => List(1, 2, 3))
 val handle = Mockito.doAnswer(answer).when(filter)
 mockedMethod(using handle).apply(ArgumentMatchers.any[Int => Boolean]())
 ```
@@ -219,3 +219,15 @@ assert(executor.calledBefore(it.compute(_: Int), it.compute(_: String)))
 ```
 
 When doing so, consider whether this behavior is a hard requirement of your system or merely an implementation detail. If it is the latter, the assertion might be an overspecification.
+
+## Referencing the Mocked Instance in a Stub
+
+A reference to the mocked instance itself is available in the stubbing context of the `on` and `onCall` methods via `it`.
+
+```scala
+  trait Counter:
+    def increment(): Counter
+
+  val counter = mock[Counter].on(() => it.increment())(_ => it)
+  assert(counter.increment().increment() == counter)
+```

--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -102,13 +102,13 @@ private trait MockSyntax:
       *   the mocked type.
       */
     inline def on[A <: Tuple, R1, R2 <: R1](method: Mock[T] ?=> MockedMethod[A, R1])(
-        stub: PartialFunction[Pack[A], R2]
+        stub: Mock[T] ?=> PartialFunction[Pack[A], R2]
     ): Mock[T] =
       assertMethodExists[A, R1]()
       val answer: Answer[R2] =
         invocation =>
           val arguments = unwrap[A](invocation.getRawArguments)
-          stub.applyOrElse(
+          stub(using mock).applyOrElse(
             pack(Tuple.fromArray(arguments).asInstanceOf[A]),
             _ => throw UnexpectedArguments(invocation.getMethod, arguments)
           )
@@ -230,13 +230,13 @@ private trait MockSyntax:
       *   the mocked type.
       */
     inline def onCall[A <: Tuple, R1, R2 <: R1](method: Mock[T] ?=> MockedMethod[A, R1])(
-        stub: PartialFunction[Int, Pack[A] => R2]
+        stub: Mock[T] ?=> PartialFunction[Int, Pack[A] => R2]
     ): Mock[T] =
       val callCount = AtomicInteger(0)
       val f =
         (args: Pack[A]) =>
           val call = callCount.incrementAndGet()
-          stub.applyOrElse(call, _ => throw UnexpectedCallNumber(call)).apply(args)
+          stub(using mock).applyOrElse(call, _ => throw UnexpectedCallNumber(call)).apply(args)
       mock.on(method)(PartialFunctionProxy(f))
 
     /** Whether the last invocation of method `a` happened before the last invocation of method `b`,

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -721,6 +721,17 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     assertEquals(counter.increment().increment(), counter)
     assertEquals(counter.times(() => it.increment()), 2)
 
+  test("return self on an onCall stub"):
+    trait Counter:
+      def increment(): Counter
+
+    val counter =
+      mock[Counter].onCall(() => it.increment()): _ =>
+        _ => it
+
+    assertEquals(counter.increment().increment(), counter)
+    assertEquals(counter.times(() => it.increment()), 2)
+
 object SmockitoSpec:
 
   abstract class Repository[T](val name: String):

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -712,6 +712,15 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     assertEquals(f(2), 4)
     assertEquals(f.calls(it.apply), List(2))
 
+  test("return self on a stub"):
+    trait Counter:
+      def increment(): Counter
+
+    val counter = mock[Counter].on(() => it.increment())(_ => it)
+
+    assertEquals(counter.increment().increment(), counter)
+    assertEquals(counter.times(() => it.increment()), 2)
+
 object SmockitoSpec:
 
   abstract class Repository[T](val name: String):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stubs can reference the mocked instance, enabling fluent/chained method calls that return the same mock.

* **Documentation**
  * Guide updated with a new section and examples showing how to reference the mocked instance in stubs.

* **Tests**
  * Added tests verifying self-referencing stubs, fluent chaining behavior, and invocation counting for chained calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->