### PR TITLE
Check for sane method selection at compile time

### DIFF
--- a/docs/_docs/guide.md
+++ b/docs/_docs/guide.md
@@ -54,6 +54,23 @@ Smockito asserts at compile time that received methods are expressions that sele
 |got unrelated expression
 ```
 
+This macro is not perfect, and there are instances where it cannot possibly catch all invalid method references. For example, if a contextual parameter is available in scope, eta-expansion will capture its value, rendering a function whose signature effectively does not exist in the mocked type.
+
+```scala
+trait Foo:
+  def describe(using Printer[String]): String
+
+given Printer[String] = ???
+
+// fails at runtime as `describe` is actually unary
+val invalidFoo = mock[Foo].on(it.describe)(_ => "foo")
+
+// you must perform manual eta-expansion here
+val validFoo = mock[Foo].on(it.describe(using _: Printer[String]))(_ => "foo")
+```
+
+Nevertheless, Smockito also performs a runtime verification using reflection to assert that the received signature exists in the mocked type, via shape comparison, and throws an `UnknownMethod` exception that clearly signals the issue if it doesn't.
+
 # Setting up Mocks
 
 With the eta-expansion and context parameters in place, setting up mocks becomes straightforward.

--- a/docs/_docs/guide.md
+++ b/docs/_docs/guide.md
@@ -43,6 +43,17 @@ This idea was shamelessly borrowed from Kotlin's [implicit name of a single para
 def it[T](using mock: Mock[T]): Mock[T] = mock
 ```
 
+## Method accessor sanity check
+
+Smockito asserts at compile time that received methods are expressions that select a method on the mock type via `it`. This is achieved with a macro that analyzes the abstract syntax tree of the method reference passed to `on`, `calls`, `times` and friends to ensure it conforms to the expected shape. If it doesn't, a compilation error is raised with a helpful message.
+
+```scala
+|    val repository = mock[Repository[User]].on(unrelated.contains)(_ => true)
+|                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+|Smockito expects a direct method reference via `it` (e.g. `it.someMethod`),
+|got unrelated expression
+```
+
 # Setting up Mocks
 
 With the eta-expansion and context parameters in place, setting up mocks becomes straightforward.

--- a/docs/_docs/guide.md
+++ b/docs/_docs/guide.md
@@ -50,7 +50,7 @@ Smockito asserts at compile time that received methods are expressions that sele
 ```scala
 |    val repository = mock[Repository[User]].on(unrelated.contains)(_ => true)
 |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-|Smockito expects a direct method reference via `it` (e.g. `it.someMethod`),
+|Smockito expects a direct method reference via `it` (e.g. `it.foo`),
 |got unrelated expression
 ```
 

--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -2,7 +2,7 @@ package com.bdmendes.smockito
 
 import Mock.mapper.*
 import com.bdmendes.smockito.Smockito.SmockitoException.*
-import com.bdmendes.smockito.internal.meta.*
+import com.bdmendes.smockito.internal.meta
 import java.lang.reflect.Method
 import java.util.concurrent.atomic.AtomicInteger
 import org.mockito.*
@@ -24,7 +24,7 @@ private trait MockSyntax:
     private inline def matching[A <: Tuple, R](methods: Iterable[Method]): List[Method] =
       // Get all methods that may correspond to our types.
       // Due to erasure, we might get extra matches.
-      val stubArgClasses = mapTuple[A, ClassTag[?]](ct).map(_.runtimeClass)
+      val stubArgClasses = meta.mapTuple[A, ClassTag[?]](ct).map(_.runtimeClass)
       val stubReturnClass = summonInline[ClassTag[R]].runtimeClass
       methods
         .filter: method =>
@@ -44,6 +44,13 @@ private trait MockSyntax:
       val methods = summonInline[ClassTag[T]].runtimeClass.getMethods
       if matching[A, R](methods).isEmpty then
         throw UnknownMethod()
+
+    private transparent inline def assertIsMethodSelection[A <: Tuple, R](
+        inline method: Mock[T] ?=> MockedMethod[A, R]
+    ): Unit =
+      ${
+        meta.abortOnInvalidMethodSelection[T, A, R]('method)
+      }
 
     private inline def unwrap[A](
         arguments: Array[Object],
@@ -101,9 +108,10 @@ private trait MockSyntax:
       * @return
       *   the mocked type.
       */
-    inline def on[A <: Tuple, R1, R2 <: R1](method: Mock[T] ?=> MockedMethod[A, R1])(
+    inline def on[A <: Tuple, R1, R2 <: R1](inline method: Mock[T] ?=> MockedMethod[A, R1])(
         stub: Mock[T] ?=> PartialFunction[Pack[A], R2]
     ): Mock[T] =
+      assertIsMethodSelection(method)
       assertMethodExists[A, R1]()
       val answer: Answer[R2] =
         invocation =>
@@ -113,7 +121,7 @@ private trait MockSyntax:
             _ => throw UnexpectedArguments(invocation.getMethod, arguments)
           )
       method(using Mockito.doAnswer(answer).when(mock)).tupled(
-        Tuple.fromArray(mapTuple[A, Any](anyMatcher)).asInstanceOf[A]
+        Tuple.fromArray(meta.mapTuple[A, Any](anyMatcher)).asInstanceOf[A]
       )
       mock
 
@@ -130,10 +138,11 @@ private trait MockSyntax:
       * @return
       *   the mocked type.
       */
-    inline def real[A <: Tuple, R](method: Mock[T] ?=> MockedMethod[A, R]): Mock[T] =
+    inline def real[A <: Tuple, R](inline method: Mock[T] ?=> MockedMethod[A, R]): Mock[T] =
+      assertIsMethodSelection(method)
       assertMethodExists[A, R]()
       method(using Mockito.doCallRealMethod().when(mock)).tupled(
-        Tuple.fromArray(mapTuple[A, Any](anyMatcher)).asInstanceOf[A]
+        Tuple.fromArray(meta.mapTuple[A, Any](anyMatcher)).asInstanceOf[A]
       )
       mock
 
@@ -145,13 +154,14 @@ private trait MockSyntax:
       * @return
       *   the received arguments.
       */
-    inline def calls[A <: Tuple, R](method: Mock[T] ?=> MockedMethod[A, R]): List[Pack[A]] =
+    inline def calls[A <: Tuple, R](inline method: Mock[T] ?=> MockedMethod[A, R]): List[Pack[A]] =
       inline erasedValue[A] match
         case _: EmptyTuple =>
           error("`calls` is not available for nullary methods. Use `times` instead.")
         case _ =>
+          assertIsMethodSelection(method)
           assertMethodExists[A, R]()
-          val argCaptors = mapTuple[A, ArgumentCaptor[?]](captor)
+          val argCaptors = meta.mapTuple[A, ArgumentCaptor[?]](captor)
           method(using Mockito.verify(mock, Mockito.atLeast(0))).tupled(
             Tuple.fromArray(argCaptors.map(_.capture())).asInstanceOf[A]
           )
@@ -169,7 +179,8 @@ private trait MockSyntax:
       * @return
       *   the number of calls to the stub.
       */
-    inline def times[A <: Tuple, R](method: Mock[T] ?=> MockedMethod[A, R]): Int =
+    inline def times[A <: Tuple, R](inline method: Mock[T] ?=> MockedMethod[A, R]): Int =
+      assertIsMethodSelection(method)
       assertMethodExists[A, R]()
       inline erasedValue[A] match
         case _: EmptyTuple =>
@@ -189,9 +200,9 @@ private trait MockSyntax:
         case _: (h *: t) =>
           // We do a little trick here: capturing the first argument is enough for counting the
           // number of calls.
-          val cap = mapTuple[h *: EmptyTuple, ArgumentCaptor[?]](captor).head
+          val cap = meta.mapTuple[h *: EmptyTuple, ArgumentCaptor[?]](captor).head
           method(using Mockito.verify(mock, Mockito.atLeast(0))).tupled(
-            Tuple.fromArray(cap.capture() +: mapTuple[t, Any](anyMatcher)).asInstanceOf[A]
+            Tuple.fromArray(cap.capture() +: meta.mapTuple[t, Any](anyMatcher)).asInstanceOf[A]
           )
           cap.getAllValues.size
 
@@ -213,7 +224,7 @@ private trait MockSyntax:
       *   the mocked type.
       */
     inline def forward[A <: Tuple, R](
-        method: Mock[T] ?=> MockedMethod[A, R],
+        inline method: Mock[T] ?=> MockedMethod[A, R],
         realInstance: T
     ): Mock[T] =
       val realMethod = method(using realInstance.asInstanceOf[Mock[T]]).packed
@@ -229,7 +240,7 @@ private trait MockSyntax:
       * @return
       *   the mocked type.
       */
-    inline def onCall[A <: Tuple, R1, R2 <: R1](method: Mock[T] ?=> MockedMethod[A, R1])(
+    inline def onCall[A <: Tuple, R1, R2 <: R1](inline method: Mock[T] ?=> MockedMethod[A, R1])(
         stub: Mock[T] ?=> PartialFunction[Int, Pack[A] => R2]
     ): Mock[T] =
       val callCount = AtomicInteger(0)
@@ -250,18 +261,20 @@ private trait MockSyntax:
       *   Whether `a` was called before `b`.
       */
     inline def calledBefore[A1 <: Tuple, R1, A2 <: Tuple, R2](
-        a: Mock[T] ?=> MockedMethod[A1, R1],
-        b: Mock[T] ?=> MockedMethod[A2, R2]
+        inline a: Mock[T] ?=> MockedMethod[A1, R1],
+        inline b: Mock[T] ?=> MockedMethod[A2, R2]
     ): Boolean =
+      assertIsMethodSelection(a)
+      assertIsMethodSelection(b)
       assertMethodExists[A1, R1]()
       assertMethodExists[A2, R2]()
       val ordered = Mockito.inOrder(mock)
       verifies:
         a(using ordered.verify(mock, Mockito.atLeastOnce)).tupled(
-          Tuple.fromArray(mapTuple[A1, Any](anyMatcher)).asInstanceOf[A1]
+          Tuple.fromArray(meta.mapTuple[A1, Any](anyMatcher)).asInstanceOf[A1]
         )
         b(using ordered.verify(mock, Mockito.atLeastOnce)).tupled(
-          Tuple.fromArray(mapTuple[A2, Any](anyMatcher)).asInstanceOf[A2]
+          Tuple.fromArray(meta.mapTuple[A2, Any](anyMatcher)).asInstanceOf[A2]
         )
 
     /** Whether the last invocation of method `a` happened after the last invocation of method `b`,
@@ -275,8 +288,8 @@ private trait MockSyntax:
       *   Whether `a` was called after `b`.
       */
     inline def calledAfter[A1 <: Tuple, R1, A2 <: Tuple, R2](
-        a: Mock[T] ?=> MockedMethod[A1, R1],
-        b: Mock[T] ?=> MockedMethod[A2, R2]
+        inline a: Mock[T] ?=> MockedMethod[A1, R1],
+        inline b: Mock[T] ?=> MockedMethod[A2, R2]
     ): Boolean = calledBefore(b, a)
 
 private object Mock:

--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -49,7 +49,7 @@ private trait MockSyntax:
         inline method: Mock[T] ?=> MockedMethod[A, R]
     ): Unit =
       ${
-        meta.abortOnInvalidMethodSelection[T, A, R]('method)
+        meta.abortOnInvalidMethodSelection[T, Mock]('method)
       }
 
     private inline def unwrap[A](

--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -45,7 +45,7 @@ private trait MockSyntax:
       if matching[A, R](methods).isEmpty then
         throw UnknownMethod()
 
-    private transparent inline def assertIsMethodSelection[A <: Tuple, R](
+    private inline def assertIsMethodSelection[A <: Tuple, R](
         inline method: Mock[T] ?=> MockedMethod[A, R]
     ): Unit =
       ${

--- a/src/main/scala/com/bdmendes/smockito/Smockito.scala
+++ b/src/main/scala/com/bdmendes/smockito/Smockito.scala
@@ -55,11 +55,7 @@ object Smockito:
     case class UnknownMethod private[smockito] ()
         extends SmockitoException(
           s"The received method does not match any of the mock object's methods. " +
-            "Are you performing eta-expansion correctly? " +
-            "Double-check if this method has contextual parameters and " +
-            "they are inadvertently being captured in the spec scope, " +
-            "one or more default parameters are being discarded, " +
-            "or a variable number of arguments is being fixed."
+            "Are you performing eta-expansion correctly?"
         )
 
     case class UnexpectedArguments private[smockito] (method: Method, arguments: Array[Object])

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -4,7 +4,7 @@ import scala.compiletime.*
 import scala.quoted.*
 import scala.reflect.ClassTag
 
-private[smockito] object meta:
+object meta:
 
   inline def mapTuple[T <: Tuple, R: ClassTag](inline f: [X] => (ClassTag[X]) ?=> R): Array[R] =
     inline erasedValue[T] match

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -1,6 +1,5 @@
 package com.bdmendes.smockito.internal
 
-import com.bdmendes.smockito.*
 import scala.compiletime.*
 import scala.quoted.*
 import scala.reflect.ClassTag
@@ -14,9 +13,9 @@ private[smockito] object meta:
       case _: (h *: t) =>
         f[h](using summonInline[ClassTag[h]]) +: mapTuple[t, R](f)
 
-  def abortOnInvalidMethodSelection[T: Type, A <: Tuple: Type, R: Type](
-      method: Expr[Mock[T] ?=> MockedMethod[A, R]]
-  )(using q: Quotes): Expr[Unit] =
+  def abortOnInvalidMethodSelection[T: Type, F[_]](expr: Expr[F[T] ?=> Any])(using
+      q: Quotes
+  ): Expr[Unit] =
     import q.reflect.*
 
     val mockType = TypeRepr.of[T]
@@ -41,9 +40,9 @@ private[smockito] object meta:
         case _ =>
           false
 
-    if !hasSelectOnMock(method.asTerm) then
+    if !hasSelectOnMock(expr.asTerm) then
       report.errorAndAbort(
-        "Smockito expects a direct method reference via `it` (e.g. `it.someMethod`), got unrelated expression"
+        "Smockito expects a direct method reference via `it` (e.g. `it.foo`), got unrelated expression"
       )
 
     '{}

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -1,6 +1,8 @@
 package com.bdmendes.smockito.internal
 
+import com.bdmendes.smockito.*
 import scala.compiletime.*
+import scala.quoted.*
 import scala.reflect.ClassTag
 
 private[smockito] object meta:
@@ -11,3 +13,44 @@ private[smockito] object meta:
         Array.empty
       case _: (h *: t) =>
         f[h](using summonInline[ClassTag[h]]) +: mapTuple[t, R](f)
+
+  def abortOnInvalidMethodSelection[T: Type, A <: Tuple: Type, R: Type](
+      method: Expr[Mock[T] ?=> MockedMethod[A, R]]
+  )(using q: Quotes): Expr[Unit] =
+    import q.reflect.*
+
+    val mockType = TypeRepr.of[T]
+
+    // Walk the tree looking for any Select whose prefix has type T (or subtype).
+    // That's the signature of `it.someMethod` (where `it: T`), as opposed to
+    // an arbitrary lambda whose body has no such selection.
+    def hasSelectOnMock(term: Term): Boolean =
+      term match
+        case Select(prefix, _) if prefix.tpe <:< mockType =>
+          true
+        case Lambda(_, body) =>
+          hasSelectOnMock(body)
+        case Apply(fn, args) =>
+          hasSelectOnMock(fn) || args.exists(hasSelectOnMock)
+        case TypeApply(fn, _) =>
+          hasSelectOnMock(fn)
+        case Typed(inner, _) =>
+          hasSelectOnMock(inner)
+        case Block(stmts, expr) =>
+          stmts.exists:
+            case t: Term =>
+              hasSelectOnMock(t)
+            case _ =>
+              false
+          || hasSelectOnMock(expr)
+        case Inlined(_, _, body) =>
+          hasSelectOnMock(body)
+        case _ =>
+          false
+
+    if !hasSelectOnMock(method.asTerm) then
+      report.errorAndAbort(
+        "Smockito expects a direct method reference via `it` (e.g. `it.someMethod`), found unrelated expression"
+      )
+
+    '{}

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -43,7 +43,7 @@ private[smockito] object meta:
 
     if !hasSelectOnMock(method.asTerm) then
       report.errorAndAbort(
-        "Smockito expects a direct method reference via `it` (e.g. `it.someMethod`), found unrelated expression"
+        "Smockito expects a direct method reference via `it` (e.g. `it.someMethod`), got unrelated expression"
       )
 
     '{}

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -23,24 +23,24 @@ object meta:
     // Walk the tree looking for any Select whose prefix has type T (or subtype).
     // That's the signature of `it.someMethod` (where `it: T`), as opposed to
     // an arbitrary lambda whose body has no such selection.
-    def hasSelectOnMock(term: Term): Boolean =
+    def hasSelectOnF(term: Term): Boolean =
       term match
         case Select(prefix, _) if prefix.tpe <:< mockType =>
           true
         case Lambda(_, body) =>
-          hasSelectOnMock(body)
+          hasSelectOnF(body)
         case Apply(fn, args) =>
-          hasSelectOnMock(fn) || args.exists(hasSelectOnMock)
+          hasSelectOnF(fn) || args.exists(hasSelectOnF)
         case TypeApply(fn, _) =>
-          hasSelectOnMock(fn)
+          hasSelectOnF(fn)
         case Block(_, expr) =>
-          hasSelectOnMock(expr)
+          hasSelectOnF(expr)
         case Inlined(_, _, body) =>
-          hasSelectOnMock(body)
+          hasSelectOnF(body)
         case _ =>
           false
 
-    if !hasSelectOnMock(expr.asTerm) then
+    if !hasSelectOnF(expr.asTerm) then
       report.errorAndAbort(
         "Smockito expects a direct method reference via `it` (e.g. `it.foo`), got unrelated expression"
       )

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -34,15 +34,8 @@ private[smockito] object meta:
           hasSelectOnMock(fn) || args.exists(hasSelectOnMock)
         case TypeApply(fn, _) =>
           hasSelectOnMock(fn)
-        case Typed(inner, _) =>
-          hasSelectOnMock(inner)
-        case Block(stmts, expr) =>
-          stmts.exists:
-            case t: Term =>
-              hasSelectOnMock(t)
-            case _ =>
-              false
-          || hasSelectOnMock(expr)
+        case Block(_, expr) =>
+          hasSelectOnMock(expr)
         case Inlined(_, _, body) =>
           hasSelectOnMock(body)
         case _ =>

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -379,15 +379,21 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
 
     assertEquals(repository.times(it.contains(_: String)), 1)
 
-  test("reject non-method-reference functions at compile time"):
-    assert(!typeChecks("""mock[Repository[User]].on((_: String) => true)(_ => true)"""))
-    assert(!typeChecks("""mock[Repository[User]].times((_: String) => true)"""))
-    assert(!typeChecks("""mock[Repository[User]].calls((_: String) => true)"""))
-    assert(!typeChecks("""mock[Repository[User]].forward((_: String) => true, null)"""))
-    assert(!typeChecks("""mock[Repository[User]].real((_: String) => true)"""))
-    assert(!typeChecks("""mock[Repository[User]].onCall((_: String) => true)(_ => _ => true)"""))
-    assert(!typeChecks("""mock[Repository[User]].calledBefore(it.exists, (_: String) => true)"""))
-    assert(!typeChecks("""mock[Repository[User]].calledAfter(it.exists, (_: String) => true)"""))
+  test("reject received unrelated expression at compile time"):
+    def assertHasRejection(errors: String) = assert(errors.contains("got unrelated expression"))
+
+    // The compiler can't see that this is evaluated below, so silence the warning by forcing it.
+    val repository = mock[Repository[User]]
+    val _ = repository
+
+    assertHasRejection(compileErrors("""repository.on((_: String) => true)(_ => true)"""))
+    assertHasRejection(compileErrors("""repository.times((_: String) => true)"""))
+    assertHasRejection(compileErrors("""repository.calls((_: String) => true)"""))
+    assertHasRejection(compileErrors("""repository.forward((_: String) => true, null)"""))
+    assertHasRejection(compileErrors("""repository.real((_: String) => true)"""))
+    assertHasRejection(compileErrors("""repository.onCall((_: String) => true)(_ => _ => true)"""))
+    assertHasRejection(compileErrors("""repository.calledBefore(it.exists, (_: String) => true)"""))
+    assertHasRejection(compileErrors("""repository.calledAfter(it.exists, (_: String) => true)"""))
 
   test("throw on unknown received method"):
     intercept[UnknownMethod]:

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -379,45 +379,17 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
 
     assertEquals(repository.times(it.contains(_: String)), 1)
 
+  test("reject non-method-reference functions at compile time"):
+    assert(!typeChecks("""mock[Repository[User]].on((_: String) => true)(_ => true)"""))
+    assert(!typeChecks("""mock[Repository[User]].times((_: String) => true)"""))
+    assert(!typeChecks("""mock[Repository[User]].calls((_: String) => true)"""))
+    assert(!typeChecks("""mock[Repository[User]].forward((_: String) => true, null)"""))
+    assert(!typeChecks("""mock[Repository[User]].real((_: String) => true)"""))
+    assert(!typeChecks("""mock[Repository[User]].onCall((_: String) => true)(_ => _ => true)"""))
+    assert(!typeChecks("""mock[Repository[User]].calledBefore(it.exists, (_: String) => true)"""))
+    assert(!typeChecks("""mock[Repository[User]].calledAfter(it.exists, (_: String) => true)"""))
+
   test("throw on unknown received method"):
-    def merge(x: User, y: User) = User(x.username + y.username)
-
-    intercept[UnknownMethod]:
-      val _ = mock[Repository[User]].on(merge)(_ => mockUsers.head)
-
-    intercept[UnknownMethod]:
-      val _ = mock[Repository[User]].times(merge)
-
-    intercept[UnknownMethod]:
-      val _ = mock[Repository[User]].calls(merge)
-
-    intercept[UnknownMethod]:
-      val _ = mock[Repository[User]].forward(merge, null)
-
-    intercept[UnknownMethod]:
-      val _ = mock[Repository[User]].onCall(merge)(_ => _ => mockUsers.head)
-
-    intercept[UnknownMethod]:
-      val _ = mock[Repository[User]].real(merge)
-
-    intercept[UnknownMethod]:
-      val _ = mock[Repository[User]].calledBefore(it.exists, merge)
-
-    intercept[UnknownMethod]:
-      val _ = mock[Repository[User]].calledBefore(merge, it.exists)
-
-    intercept[UnknownMethod]:
-      val _ = mock[Repository[User]].calledBefore(merge, merge)
-
-    intercept[UnknownMethod]:
-      val _ = mock[Repository[User]].calledAfter(it.exists, merge)
-
-    intercept[UnknownMethod]:
-      val _ = mock[Repository[User]].calledAfter(merge, it.exists)
-
-    intercept[UnknownMethod]:
-      val _ = mock[Repository[User]].calledAfter(merge, merge)
-
     intercept[UnknownMethod]:
       // It also happens frequently that a method with contextuals gets eta-expanded
       // in a way that's not intended due to an implicit capture.

--- a/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
@@ -19,7 +19,7 @@ class MetaSpec extends munit.FunSuite:
     // so force one of them to suppress the warning.
     val _ = target
 
-    assert(!hasRejection("abortInvalidEntry(target.charAt))"))
+    assert(!hasRejection("abortInvalidEntry(target.charAt)"))
     assert(!hasRejection("abortInvalidEntry(target.charAt(_: Int))"))
     assert(!hasRejection("abortInvalidEntry((pos: Int) => target.charAt(pos))"))
     assert(hasRejection("abortInvalidEntry(0)"))

--- a/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
@@ -1,6 +1,6 @@
 package com.bdmendes.smockito.internal
 
-import meta.mapTuple
+import meta.*
 import scala.reflect.ClassTag
 
 class MetaSpec extends munit.FunSuite:

--- a/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
@@ -1,5 +1,6 @@
 package com.bdmendes.smockito.internal
 
+import MetaSpec.*
 import meta.*
 import scala.reflect.ClassTag
 
@@ -9,3 +10,26 @@ class MetaSpec extends munit.FunSuite:
     val f = [X] => (x: ClassTag[X]) ?=> x.runtimeClass.getSimpleName
 
     assert(mapTuple[(String, Int, Long), String](f).sameElements(Array("String", "int", "long")))
+
+  test("abort on invalid method selection"):
+    inline def hasRejection(expr: String): Boolean =
+      compileErrors(expr).contains("got unrelated expression")
+
+    // The compiler can't see that `target` and `abortInvalidEntry` are being referenced below,
+    // so force one of them to suppress the warning.
+    val _ = target
+
+    assert(!hasRejection("abortInvalidEntry(target.charAt))"))
+    assert(!hasRejection("abortInvalidEntry(target.charAt(_: Int))"))
+    assert(!hasRejection("abortInvalidEntry((pos: Int) => target.charAt(pos))"))
+    assert(hasRejection("abortInvalidEntry(0)"))
+    assert(hasRejection("abortInvalidEntry(() => true)"))
+    assert(hasRejection("abortInvalidEntry((_: String) => true)"))
+
+private object MetaSpec:
+  val target: String = "Some string"
+
+  private inline def abortInvalidEntry[T, F[_]](inline expr: Any): Unit =
+    ${
+      abortOnInvalidMethodSelection[T, F]('expr)
+    }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compile-time validation of method-reference expressions in stubbing and verification APIs; invalid selectors are rejected with clear compile-time diagnostics.

* **Behavioral Changes**
  * Core mocking APIs now enforce compile-time method-selection checks (some call-site parameters are required to be inline).
  * Shortened unknown-method error text for clearer output.

* **Documentation**
  * Added guide section with examples showing invalid selector patterns and compiler messages.

* **Tests**
  * Tests updated to assert compile-time rejections for invalid method-selection expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->