### PR TITLE
Rework times to match via name and introduce matched method shape check

### DIFF
--- a/docs/_docs/guide.md
+++ b/docs/_docs/guide.md
@@ -53,7 +53,7 @@ Smockito asserts at compile time that received methods are expressions that sele
 |Expected selection of a mockable method of Repository[User]
 ```
 
-Eta-expansion in Scala has its quirks: for instance, it captures any context parameters in scope, rendering a method that effectively does not exist in the JVM bytecode and that Mockito cannot directly mock. Smockito guards against this by rejecting method references whose shape does not match the referenced method in the mocked type.
+Eta-expansion in Scala has its quirks: for instance, it captures any context parameters in scope, rendering a method that effectively does not exist in the JVM bytecode and that Mockito cannot directly mock. Smockito guards against this by rejecting method references whose shape does not match the referenced method in the mocked type, directing the user to eta-expand manually.
 
 ```scala
 |trait Printer[A]
@@ -64,8 +64,7 @@ Eta-expansion in Scala has its quirks: for instance, it captures any context par
 |
 |    val invalidFoo = mock[Foo].on(it.describe)(_ => "foo")
 |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-|Method 'describe' in Foo has 2 parameters but received function expects 1;
-|eta-expand manually
+|Method describe in Foo has 2 parameters but received function expects 1
 ```
 
 # Setting up Mocks

--- a/docs/_docs/guide.md
+++ b/docs/_docs/guide.md
@@ -50,8 +50,7 @@ Smockito asserts at compile time that received methods are expressions that sele
 ```scala
 |    val repository = mock[Repository[User]].on(unrelated.contains)(_ => true)
 |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-|Expected selection of a mockable method of Repository[User],
-|got unrelated expression
+|Expected selection of a mockable method of Repository[User]
 ```
 
 Eta-expansion in Scala has its quirks: for instance, it captures any context parameters in scope, rendering a method that effectively does not exist in the JVM bytecode and that Mockito cannot directly mock. Smockito guards against this by rejecting method references whose shape does not match the referenced method in the mocked type.

--- a/docs/_docs/guide.md
+++ b/docs/_docs/guide.md
@@ -56,11 +56,11 @@ Smockito asserts at compile time that received methods are expressions that sele
 Eta-expansion in Scala has its quirks: for instance, it captures any context parameters in scope, rendering a method that effectively does not exist in the JVM bytecode and that Mockito cannot directly mock. Smockito guards against this by rejecting method references whose shape does not match the referenced method in the mocked type, directing the user to eta-expand manually.
 
 ```scala
-|trait Printer[A]
-|trait Foo:
-|  def describe(upper: Boolean)(using Printer[String]): String
+|    trait Printer[A]
+|    trait Foo:
+|      def describe(upper: Boolean)(using Printer[String]): String
 |
-|given Printer[String] = ???
+|    given Printer[String] = ???
 |
 |    val invalidFoo = mock[Foo].on(it.describe)(_ => "foo")
 |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/_docs/guide.md
+++ b/docs/_docs/guide.md
@@ -50,26 +50,24 @@ Smockito asserts at compile time that received methods are expressions that sele
 ```scala
 |    val repository = mock[Repository[User]].on(unrelated.contains)(_ => true)
 |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-|Smockito expects a direct method reference via `it` (e.g. `it.foo`),
+|Expected selection of a mockable method of Repository[User],
 |got unrelated expression
 ```
 
-This macro is not perfect, and there are instances where it cannot possibly catch all invalid method references. For example, if a contextual parameter is available in scope, eta-expansion will capture its value, rendering a function whose signature effectively does not exist in the mocked type.
+Eta-expansion in Scala has its quirks: for instance, it captures any context parameters in scope, rendering a method that effectively does not exist in the JVM bytecode and that Mockito cannot directly mock. Smockito guards against this by rejecting method references whose shape does not match the referenced method in the mocked type.
 
 ```scala
-trait Foo:
-  def describe(using Printer[String]): String
-
-given Printer[String] = ???
-
-// fails at runtime as `describe` is actually unary
-val invalidFoo = mock[Foo].on(it.describe)(_ => "foo")
-
-// you must perform manual eta-expansion here
-val validFoo = mock[Foo].on(it.describe(using _: Printer[String]))(_ => "foo")
+|trait Printer[A]
+|trait Foo:
+|  def describe(upper: Boolean)(using Printer[String]): String
+|
+|given Printer[String] = ???
+|
+|    val invalidFoo = mock[Foo].on(it.describe)(_ => "foo")
+|                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+|Method 'describe' has 2 parameters but received function expects 1;
+|eta-expand manually
 ```
-
-Nevertheless, Smockito also performs a runtime verification using reflection to assert that the received signature exists in the mocked type, via shape comparison, and throws an `UnknownMethod` exception that clearly signals the issue if it doesn't.
 
 # Setting up Mocks
 

--- a/docs/_docs/guide.md
+++ b/docs/_docs/guide.md
@@ -65,7 +65,7 @@ Eta-expansion in Scala has its quirks: for instance, it captures any context par
 |
 |    val invalidFoo = mock[Foo].on(it.describe)(_ => "foo")
 |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-|Method 'describe' has 2 parameters but received function expects 1;
+|Method 'describe' in Foo has 2 parameters but received function expects 1;
 |eta-expand manually
 ```
 

--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -160,8 +160,9 @@ private trait MockSyntax:
             .mockingDetails(mock)
             .getInvocations
             .asScala
-            .filter(inv =>
-              inv.getMethod.getName == methodName && inv.getMethod.getParameters.isEmpty
+            .filter(invocation =>
+              invocation.getMethod.getName == methodName &&
+                invocation.getMethod.getParameters.isEmpty
             )
             .size
         case _: (h *: t) =>

--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -21,30 +21,11 @@ private trait MockSyntax:
 
   extension [T](mock: Mock[T])
 
-    private inline def matching[A <: Tuple, R](methods: Iterable[Method]): List[Method] =
-      // Get all methods that may correspond to our types.
-      // Due to erasure, we might get extra matches.
-      val stubArgClasses = meta.mapTuple[A, ClassTag[?]](ct).map(_.runtimeClass)
-      val stubReturnClass = summonInline[ClassTag[R]].runtimeClass
-      methods
-        .filter: method =>
-          (
-            method.getReturnType.isAssignableFrom(stubReturnClass) ||
-              (stubReturnClass.isPrimitive && method.getReturnType == classOf[Object])
-          ) && stubArgClasses.length == method.getParameterTypes.length &&
-            stubArgClasses
-              .zip(method.getParameterTypes)
-              .forall: (s, m) =>
-                m.isAssignableFrom(s) ||
-                  (s.isPrimitive && m == classOf[Object]) ||
-                  classOf[Function0[?]].isAssignableFrom(m)
-        .toList
-
-    private inline def assertValidMethodSelection[A <: Tuple, R](
+    private inline def validateAndRetrieveName[A <: Tuple, R](
         inline method: Mock[T] ?=> MockedMethod[A, R]
-    ): Unit =
+    ): String =
       ${
-        meta.abortOnInvalidMethodSelection[T, Mock, A]('method)
+        meta.matchedMethodName[T, Mock, A]('method)
       }
 
     private inline def unwrap[A](
@@ -106,7 +87,7 @@ private trait MockSyntax:
     inline def on[A <: Tuple, R1, R2 <: R1](inline method: Mock[T] ?=> MockedMethod[A, R1])(
         stub: Mock[T] ?=> PartialFunction[Pack[A], R2]
     ): Mock[T] =
-      assertValidMethodSelection(method)
+      validateAndRetrieveName(method)
       val answer: Answer[R2] =
         invocation =>
           val arguments = unwrap[A](invocation.getRawArguments)
@@ -133,7 +114,7 @@ private trait MockSyntax:
       *   the mocked type.
       */
     inline def real[A <: Tuple, R](inline method: Mock[T] ?=> MockedMethod[A, R]): Mock[T] =
-      assertValidMethodSelection(method)
+      validateAndRetrieveName(method)
       method(using Mockito.doCallRealMethod().when(mock)).tupled(
         Tuple.fromArray(meta.mapTuple[A, Any](anyMatcher)).asInstanceOf[A]
       )
@@ -152,7 +133,7 @@ private trait MockSyntax:
         case _: EmptyTuple =>
           error("`calls` is not available for nullary methods; use `times` instead")
         case _ =>
-          assertValidMethodSelection(method)
+          validateAndRetrieveName(method)
           val argCaptors = meta.mapTuple[A, ArgumentCaptor[?]](captor)
           method(using Mockito.verify(mock, Mockito.atLeast(0))).tupled(
             Tuple.fromArray(argCaptors.map(_.capture())).asInstanceOf[A]
@@ -172,25 +153,20 @@ private trait MockSyntax:
       *   the number of calls to the stub.
       */
     inline def times[A <: Tuple, R](inline method: Mock[T] ?=> MockedMethod[A, R]): Int =
-      assertValidMethodSelection(method)
+      val methodName = validateAndRetrieveName(method)
       inline erasedValue[A] match
         case _: EmptyTuple =>
-          // Unfortunately, Mockito does not expose a reliable API for this use case.
-          // We have to check all matching invocations, minding type erasure, and manually
-          // validate the result.
-          val invocations =
-            matching[EmptyTuple, R](
-              Mockito.mockingDetails(mock).getInvocations.asScala.map(_.getMethod)
-            ).size
-          val validInvocations = (invocations to 1 by -1).find: count =>
-            verifies:
-              method(using Mockito.verify(mock, Mockito.times(count))).tupled(
-                EmptyTuple.asInstanceOf[A]
-              )
-          validInvocations.getOrElse(0)
+          Mockito
+            .mockingDetails(mock)
+            .getInvocations
+            .asScala
+            .filter(inv =>
+              inv.getMethod.getName == methodName && inv.getMethod.getParameters.isEmpty
+            )
+            .size
         case _: (h *: t) =>
-          // We do a little trick here: capturing the first argument is enough for counting the
-          // number of calls.
+          // Non-nullary methods may be overloaded, so we resort to a little trick here: we capture
+          // the first argument only, which is enough for counting the number of calls.
           val cap = meta.mapTuple[h *: EmptyTuple, ArgumentCaptor[?]](captor).head
           method(using Mockito.verify(mock, Mockito.atLeast(0))).tupled(
             Tuple.fromArray(cap.capture() +: meta.mapTuple[t, Any](anyMatcher)).asInstanceOf[A]
@@ -255,8 +231,8 @@ private trait MockSyntax:
         inline a: Mock[T] ?=> MockedMethod[A1, R1],
         inline b: Mock[T] ?=> MockedMethod[A2, R2]
     ): Boolean =
-      assertValidMethodSelection(a)
-      assertValidMethodSelection(b)
+      validateAndRetrieveName(a)
+      validateAndRetrieveName(b)
       val ordered = Mockito.inOrder(mock)
       verifies:
         a(using ordered.verify(mock, Mockito.atLeastOnce)).tupled(

--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -40,12 +40,7 @@ private trait MockSyntax:
                   classOf[Function0[?]].isAssignableFrom(m)
         .toList
 
-    private inline def assertMethodExists[A <: Tuple, R](): Unit =
-      val methods = summonInline[ClassTag[T]].runtimeClass.getMethods
-      if matching[A, R](methods).isEmpty then
-        throw UnknownMethod()
-
-    private inline def assertIsMethodSelection[A <: Tuple, R](
+    private inline def assertValidMethodSelection[A <: Tuple, R](
         inline method: Mock[T] ?=> MockedMethod[A, R]
     ): Unit =
       ${
@@ -111,8 +106,7 @@ private trait MockSyntax:
     inline def on[A <: Tuple, R1, R2 <: R1](inline method: Mock[T] ?=> MockedMethod[A, R1])(
         stub: Mock[T] ?=> PartialFunction[Pack[A], R2]
     ): Mock[T] =
-      assertIsMethodSelection(method)
-      assertMethodExists[A, R1]()
+      assertValidMethodSelection(method)
       val answer: Answer[R2] =
         invocation =>
           val arguments = unwrap[A](invocation.getRawArguments)
@@ -139,8 +133,7 @@ private trait MockSyntax:
       *   the mocked type.
       */
     inline def real[A <: Tuple, R](inline method: Mock[T] ?=> MockedMethod[A, R]): Mock[T] =
-      assertIsMethodSelection(method)
-      assertMethodExists[A, R]()
+      assertValidMethodSelection(method)
       method(using Mockito.doCallRealMethod().when(mock)).tupled(
         Tuple.fromArray(meta.mapTuple[A, Any](anyMatcher)).asInstanceOf[A]
       )
@@ -157,10 +150,9 @@ private trait MockSyntax:
     inline def calls[A <: Tuple, R](inline method: Mock[T] ?=> MockedMethod[A, R]): List[Pack[A]] =
       inline erasedValue[A] match
         case _: EmptyTuple =>
-          error("`calls` is not available for nullary methods. Use `times` instead.")
+          error("`calls` is not available for nullary methods; use `times` instead")
         case _ =>
-          assertIsMethodSelection(method)
-          assertMethodExists[A, R]()
+          assertValidMethodSelection(method)
           val argCaptors = meta.mapTuple[A, ArgumentCaptor[?]](captor)
           method(using Mockito.verify(mock, Mockito.atLeast(0))).tupled(
             Tuple.fromArray(argCaptors.map(_.capture())).asInstanceOf[A]
@@ -180,8 +172,7 @@ private trait MockSyntax:
       *   the number of calls to the stub.
       */
     inline def times[A <: Tuple, R](inline method: Mock[T] ?=> MockedMethod[A, R]): Int =
-      assertIsMethodSelection(method)
-      assertMethodExists[A, R]()
+      assertValidMethodSelection(method)
       inline erasedValue[A] match
         case _: EmptyTuple =>
           // Unfortunately, Mockito does not expose a reliable API for this use case.
@@ -264,10 +255,8 @@ private trait MockSyntax:
         inline a: Mock[T] ?=> MockedMethod[A1, R1],
         inline b: Mock[T] ?=> MockedMethod[A2, R2]
     ): Boolean =
-      assertIsMethodSelection(a)
-      assertIsMethodSelection(b)
-      assertMethodExists[A1, R1]()
-      assertMethodExists[A2, R2]()
+      assertValidMethodSelection(a)
+      assertValidMethodSelection(b)
       val ordered = Mockito.inOrder(mock)
       verifies:
         a(using ordered.verify(mock, Mockito.atLeastOnce)).tupled(

--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -49,7 +49,7 @@ private trait MockSyntax:
         inline method: Mock[T] ?=> MockedMethod[A, R]
     ): Unit =
       ${
-        meta.abortOnInvalidMethodSelection[T, Mock]('method)
+        meta.abortOnInvalidMethodSelection[T, Mock, A]('method)
       }
 
     private inline def unwrap[A](

--- a/src/main/scala/com/bdmendes/smockito/Smockito.scala
+++ b/src/main/scala/com/bdmendes/smockito/Smockito.scala
@@ -52,12 +52,6 @@ object Smockito:
 
   object SmockitoException:
 
-    case class UnknownMethod private[smockito] ()
-        extends SmockitoException(
-          s"The received method does not match any of the mock object's methods. " +
-            "Are you performing eta-expansion correctly?"
-        )
-
     case class UnexpectedArguments private[smockito] (method: Method, arguments: Array[Object])
         extends SmockitoException(
           s"${describeMethod(method)} received unexpected arguments: " +

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -54,8 +54,9 @@ object meta:
           false
 
     if !findAndCheck(expr.asTerm) then
+      val typeName = targetType.show(using Printer.TypeReprShortCode)
       report.errorAndAbort(
-        "Expected selection of a mockable method on the mocked type, got unrelated expression"
+        s"Expected selection of a mockable method of $typeName, got unrelated expression"
       )
 
     '{}

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -35,7 +35,7 @@ object meta:
         case s @ Select(prefix, _) if prefix.tpe <:< targetType =>
           val actualArity = s.symbol.paramSymss.filterNot(_.exists(_.isType)).map(_.length).sum
           if actualArity != expectedArity then
-            val plural = Option.when(actualArity >= 0)("s").getOrElse("")
+            val plural = Option.when(actualArity != 1)("s").getOrElse("")
             report.errorAndAbort(
               s"Method ${s.symbol.name} in $typeName has $actualArity parameter$plural " +
                 s"but received function expects $expectedArity"

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -13,9 +13,9 @@ object meta:
       case _: (h *: t) =>
         f[h](using summonInline[ClassTag[h]]) +: mapTuple[t, R](f)
 
-  def abortOnInvalidMethodSelection[T: Type, F[_], A <: Tuple: Type](expr: Expr[F[T] ?=> Any])(using
+  def matchedMethodName[T: Type, F[_], A <: Tuple: Type](expr: Expr[F[T] ?=> Any])(using
       q: Quotes
-  ): Expr[Unit] =
+  ): Expr[String] =
     import q.reflect.*
 
     val targetType = TypeRepr.of[T]
@@ -30,7 +30,7 @@ object meta:
         case _ =>
           report.errorAndAbort("Could not determine expected arity")
 
-    def findAndCheck(term: Term): Boolean =
+    def findAndCheck(term: Term): Option[String] =
       term match
         case s @ Select(prefix, _) if prefix.tpe <:< targetType =>
           val actualArity = s.symbol.paramSymss.filterNot(_.exists(_.isType)).map(_.length).sum
@@ -40,11 +40,11 @@ object meta:
               s"Method '${s.symbol.name}' in ${typeName} has $actualArity parameter${plural} " +
                 s"but received function expects $expectedArity; eta-expand manually"
             )
-          true
+          Some(s.symbol.name)
         case Lambda(_, body) =>
           findAndCheck(body)
         case Apply(fn, args) =>
-          findAndCheck(fn) || args.exists(findAndCheck)
+          findAndCheck(fn).orElse(args.iterator.flatMap(findAndCheck).nextOption())
         case TypeApply(fn, _) =>
           findAndCheck(fn)
         case Block(_, e) =>
@@ -52,9 +52,10 @@ object meta:
         case Inlined(_, _, body) =>
           findAndCheck(body)
         case _ =>
-          false
+          None
 
-    if !findAndCheck(expr.asTerm) then
-      report.errorAndAbort(s"Expected selection of a mockable method of $typeName")
-
-    '{}
+    findAndCheck(expr.asTerm) match
+      case Some(methodName) =>
+        Expr(methodName)
+      case None =>
+        report.errorAndAbort(s"Expected selection of a mockable method of $typeName")

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -13,36 +13,49 @@ object meta:
       case _: (h *: t) =>
         f[h](using summonInline[ClassTag[h]]) +: mapTuple[t, R](f)
 
-  def abortOnInvalidMethodSelection[T: Type, F[_]](expr: Expr[F[T] ?=> Any])(using
+  def abortOnInvalidMethodSelection[T: Type, F[_], A <: Tuple: Type](expr: Expr[F[T] ?=> Any])(using
       q: Quotes
   ): Expr[Unit] =
     import q.reflect.*
 
     val targetType = TypeRepr.of[T]
 
-    // Walk the tree looking for any Select whose prefix has type T (or subtype).
-    // That's the signature of `it.someMethod` (where `it: T`), as opposed to
-    // an arbitrary lambda whose body has no such selection.
-    def hasSelectOnF(term: Term): Boolean =
+    val expectedArity: Int =
+      TypeRepr.of[A].dealias match
+        case t if t =:= TypeRepr.of[EmptyTuple] =>
+          0
+        case AppliedType(_, args) =>
+          args.length
+        case _ =>
+          -1
+
+    def findAndCheck(term: Term): Boolean =
       term match
-        case Select(prefix, _) if prefix.tpe <:< targetType =>
+        case s @ Select(prefix, _) if prefix.tpe <:< targetType =>
+          val actualArity = s.symbol.paramSymss.filterNot(_.exists(_.isType)).map(_.length).sum
+          if expectedArity >= 0 && actualArity != expectedArity then
+            val plural = Option.when(actualArity >= 0)("s").getOrElse("")
+            report.errorAndAbort(
+              s"Method '${s.symbol.name}' has $actualArity parameter${plural} " +
+                s"but received function expects $expectedArity; eta-expand manually"
+            )
           true
         case Lambda(_, body) =>
-          hasSelectOnF(body)
+          findAndCheck(body)
         case Apply(fn, args) =>
-          hasSelectOnF(fn) || args.exists(hasSelectOnF)
+          findAndCheck(fn) || args.exists(findAndCheck)
         case TypeApply(fn, _) =>
-          hasSelectOnF(fn)
-        case Block(_, expr) =>
-          hasSelectOnF(expr)
+          findAndCheck(fn)
+        case Block(_, e) =>
+          findAndCheck(e)
         case Inlined(_, _, body) =>
-          hasSelectOnF(body)
+          findAndCheck(body)
         case _ =>
           false
 
-    if !hasSelectOnF(expr.asTerm) then
+    if !findAndCheck(expr.asTerm) then
       report.errorAndAbort(
-        "Smockito expects a direct method reference via `it` (e.g. `it.foo`), got unrelated expression"
+        "Expected selection of a mockable method on the mocked type, got unrelated expression"
       )
 
     '{}

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -19,7 +19,7 @@ object meta:
     import q.reflect.*
 
     val targetType = TypeRepr.of[T]
-    val typeName = targetType.show(using Printer.TypeReprShortCode)
+    lazy val typeName = targetType.show(using Printer.TypeReprShortCode)
 
     val expectedArity: Int =
       TypeRepr.of[A].dealias match

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -28,13 +28,13 @@ object meta:
         case AppliedType(_, args) =>
           args.length
         case _ =>
-          -1
+          report.errorAndAbort("Could not determine expected arity")
 
     def findAndCheck(term: Term): Boolean =
       term match
         case s @ Select(prefix, _) if prefix.tpe <:< targetType =>
           val actualArity = s.symbol.paramSymss.filterNot(_.exists(_.isType)).map(_.length).sum
-          if expectedArity >= 0 && actualArity != expectedArity then
+          if actualArity != expectedArity then
             val plural = Option.when(actualArity >= 0)("s").getOrElse("")
             report.errorAndAbort(
               s"Method '${s.symbol.name}' in ${typeName} has $actualArity parameter${plural} " +

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -37,8 +37,8 @@ object meta:
           if actualArity != expectedArity then
             val plural = Option.when(actualArity >= 0)("s").getOrElse("")
             report.errorAndAbort(
-              s"Method '${s.symbol.name}' in ${typeName} has $actualArity parameter${plural} " +
-                s"but received function expects $expectedArity; eta-expand manually"
+              s"Method ${s.symbol.name} in $typeName has $actualArity parameter$plural " +
+                s"but received function expects $expectedArity"
             )
           Some(s.symbol.name)
         case Lambda(_, body) =>

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -19,6 +19,7 @@ object meta:
     import q.reflect.*
 
     val targetType = TypeRepr.of[T]
+    val typeName = targetType.show(using Printer.TypeReprShortCode)
 
     val expectedArity: Int =
       TypeRepr.of[A].dealias match
@@ -36,7 +37,7 @@ object meta:
           if expectedArity >= 0 && actualArity != expectedArity then
             val plural = Option.when(actualArity >= 0)("s").getOrElse("")
             report.errorAndAbort(
-              s"Method '${s.symbol.name}' has $actualArity parameter${plural} " +
+              s"Method '${s.symbol.name}' in ${typeName} has $actualArity parameter${plural} " +
                 s"but received function expects $expectedArity; eta-expand manually"
             )
           true
@@ -54,7 +55,6 @@ object meta:
           false
 
     if !findAndCheck(expr.asTerm) then
-      val typeName = targetType.show(using Printer.TypeReprShortCode)
       report.errorAndAbort(
         s"Expected selection of a mockable method of $typeName, got unrelated expression"
       )

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -55,8 +55,6 @@ object meta:
           false
 
     if !findAndCheck(expr.asTerm) then
-      report.errorAndAbort(
-        s"Expected selection of a mockable method of $typeName, got unrelated expression"
-      )
+      report.errorAndAbort(s"Expected selection of a mockable method of $typeName")
 
     '{}

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -379,7 +379,7 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
 
     assertEquals(repository.times(it.contains(_: String)), 1)
 
-  test("reject received unrelated expression at compile time"):
+  test("reject received unrelated expression"):
     def assertHasRejection(errors: String) = assert(errors.contains("got unrelated expression"))
 
     // The compiler can't see that this is evaluated below, so silence the warning by forcing it.
@@ -395,12 +395,14 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     assertHasRejection(compileErrors("""repository.calledBefore(it.exists, (_: String) => true)"""))
     assertHasRejection(compileErrors("""repository.calledAfter(it.exists, (_: String) => true)"""))
 
-  test("throw on unknown received method"):
-    intercept[UnknownMethod]:
-      // It also happens frequently that a method with contextuals gets eta-expanded
-      // in a way that's not intended due to an implicit capture.
-      given User = mockUsers.head
-      val _ = mock[Repository[User]].on(it.greet)(_ => "hi!")
+  test("reject unknown received method"):
+    given User = mockUsers.head
+    val _ = summon[User]
+
+    def assertHasRejection(errors: String) = assert(errors.contains("eta-expand manually"))
+
+    assertHasRejection(compileErrors("""mock[Repository[User]].on(it.greet)(_ => "hi!")"""))
+    assertHasRejection(compileErrors("""mock[Repository[User]].on(it.getNames)(_ => "bdmendes")"""))
 
   test("dispatch a method to a real instance"):
     val mockRepository = mock[Repository[User]].forward(it.exists, realRepository)

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -400,7 +400,7 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     given User = mockUsers.head
     val _ = summon[User]
 
-    def assertHasRejection(errors: String) = assert(errors.contains("eta-expand manually"))
+    def assertHasRejection(errors: String) = assert(errors.contains("received function expects"))
 
     assertHasRejection(compileErrors("""mock[Repository[User]].on(it.greet)(_ => "hi!")"""))
     assertHasRejection(compileErrors("""mock[Repository[User]].on(it.getNames)(_ => "bdmendes")"""))

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -380,7 +380,8 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     assertEquals(repository.times(it.contains(_: String)), 1)
 
   test("reject received unrelated expression"):
-    def assertHasRejection(errors: String) = assert(errors.contains("got unrelated expression"))
+    def assertHasRejection(errors: String) =
+      assert(errors.contains("Expected selection of a mockable method"))
 
     // The compiler can't see that this is evaluated below, so silence the warning by forcing it.
     val repository = mock[Repository[User]]

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -379,6 +379,18 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
 
     assertEquals(repository.times(it.contains(_: String)), 1)
 
+  test("count calls on overloaded methods with different arities"):
+    val repository =
+      mock[Repository[User]]
+        .on(() => it.get)(_ => List.empty)
+        .on(it.get(_: Boolean))(_ => List.empty)
+
+    val _ = repository.get
+    val _ = repository.get(true)
+
+    assertEquals(repository.times(() => it.get), 1)
+    assertEquals(repository.times(it.get(_: Boolean)), 1)
+
   test("reject received unrelated expression"):
     def assertHasRejection(errors: String) =
       assert(errors.contains("Expected selection of a mockable method"))
@@ -720,6 +732,7 @@ object SmockitoSpec:
     def track(): Unit
     def tag[V](x: List[V]): (List[V], List[String])
     def get: List[T]
+    def get(odd: Boolean): List[T]
     def getNames: List[String]
     def exists(username: String): Boolean
     def hasCount(count: => Int): Boolean
@@ -754,6 +767,7 @@ object SmockitoSpec:
       override def tag[V](x: List[V]): (List[V], List[String]) =
         (x, x.map(y => s"${longName}_${y}"))
       override def get: List[User] = mockUsers
+      override def get(odd: Boolean): List[User] = mockUsers
       override def getNames: List[String] = mockUsers.map(_.username)
       override def exists(username: String): Boolean = getNames.contains(username)
       override def hasCount(count: => Int): Boolean = getNames.size == count

--- a/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
@@ -34,5 +34,5 @@ private object MetaSpec:
 
   private inline def abortInvalidEntry[T, F[_]](inline expr: Any): Unit =
     ${
-      abortOnInvalidMethodSelection[T, F, Tuple1[?]]('expr)
+      matchedMethodName[T, F, Tuple1[?]]('expr)
     }

--- a/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
@@ -15,24 +15,21 @@ class MetaSpec extends munit.FunSuite:
     inline def hasRejection(expr: String): Boolean =
       compileErrors(expr).contains("Expected selection of a mockable method")
 
-    // The compiler can't see that `target` and `abortInvalidEntry` are being referenced below,
-    // so force one of them to suppress the warning.
-    val _ = target
+    assertEquals(matchedMethodEntry[String, Id](target.charAt), "charAt")
+    assertEquals(matchedMethodEntry[String, Id](target.charAt(_: Int)), "charAt")
+    assertEquals(matchedMethodEntry[String, Id]((pos: Int) => target.charAt(pos)), "charAt")
 
-    assert(!hasRejection("abortInvalidEntry[String, Id](target.charAt)"))
-    assert(!hasRejection("abortInvalidEntry[String, Id](target.charAt(_: Int))"))
-    assert(!hasRejection("abortInvalidEntry[String, Id]((pos: Int) => target.charAt(pos))"))
-    assert(hasRejection("abortInvalidEntry[String, Id](0)"))
-    assert(hasRejection("abortInvalidEntry[Int, Id](target.charAt)"))
-    assert(hasRejection("abortInvalidEntry[String, Id](() => true)"))
-    assert(hasRejection("abortInvalidEntry[String, Id]((_: String) => true)"))
+    assert(hasRejection("matchedMethodEntry[String, Id](0)"))
+    assert(hasRejection("matchedMethodEntry[Int, Id](target.charAt)"))
+    assert(hasRejection("matchedMethodEntry[String, Id](() => true)"))
+    assert(hasRejection("matchedMethodEntry[String, Id]((_: String) => true)"))
 
 private object MetaSpec:
   opaque type Id[+T] <: T = T
 
   val target: Id[String] = "Some string"
 
-  private inline def abortInvalidEntry[T, F[_]](inline expr: Any): Unit =
+  private inline def matchedMethodEntry[T, F[_]](inline expr: Any): String =
     ${
       matchedMethodName[T, F, Tuple1[?]]('expr)
     }

--- a/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
@@ -34,5 +34,5 @@ private object MetaSpec:
 
   private inline def abortInvalidEntry[T, F[_]](inline expr: Any): Unit =
     ${
-      abortOnInvalidMethodSelection[T, F]('expr)
+      abortOnInvalidMethodSelection[T, F, Tuple1[?]]('expr)
     }

--- a/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
@@ -13,7 +13,7 @@ class MetaSpec extends munit.FunSuite:
 
   test("abort on invalid method selection"):
     inline def hasRejection(expr: String): Boolean =
-      compileErrors(expr).contains("got unrelated expression")
+      compileErrors(expr).contains("Expected selection of a mockable method")
 
     // The compiler can't see that `target` and `abortInvalidEntry` are being referenced below,
     // so force one of them to suppress the warning.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guide with improved compile-time error messages showing parameter-count mismatches and eta-expansion guidance.

* **Improvements**
  * Enhanced compile-time validation for method references with clearer error messaging directing users to manually eta-expand when method signatures don't match mock types.
  * Removed `UnknownMethod` exception from public API in favor of compile-time diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->