### PR TITLE
Match return type of stub at compile time

### DIFF
--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -25,7 +25,7 @@ private trait MockSyntax:
         inline method: Mock[T] ?=> MockedMethod[A, R]
     ): String =
       ${
-        meta.matchedMethodName[T, Mock, A]('method)
+        meta.matchedMethodName[T, Mock, A, R]('method)
       }
 
     private inline def unwrap[A](

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -13,15 +13,17 @@ object meta:
       case _: (h *: t) =>
         f[h](using summonInline[ClassTag[h]]) +: mapTuple[t, R](f)
 
-  def matchedMethodName[T: Type, F[_], A <: Tuple: Type](expr: Expr[F[T] ?=> Any])(using
+  def matchedMethodName[T: Type, F[_], A <: Tuple: Type, R: Type](expr: Expr[F[T] ?=> Any])(using
       q: Quotes
   ): Expr[String] =
     import q.reflect.*
 
-    val targetType = TypeRepr.of[T]
-    lazy val typeName = targetType.show(using Printer.TypeReprShortCode)
+    given Printer[TypeRepr] = Printer.TypeReprShortCode
 
-    val expectedArity: Int =
+    val targetType = TypeRepr.of[T]
+    val returnType = TypeRepr.of[R]
+
+    lazy val expectedArity: Int =
       TypeRepr.of[A].dealias match
         case t if t =:= TypeRepr.of[EmptyTuple] =>
           0
@@ -30,17 +32,36 @@ object meta:
         case _ =>
           report.errorAndAbort("Could not determine expected arity")
 
+    def finalResultType(t: TypeRepr): TypeRepr =
+      t match
+        case MethodType(_, _, ret) =>
+          finalResultType(ret)
+        case PolyType(_, _, ret) =>
+          finalResultType(ret)
+        case _ =>
+          t
+
+    def checkAndReturn(sym: Symbol, methodReturn: TypeRepr): Option[String] =
+      val actualArity = sym.paramSymss.filterNot(_.exists(_.isType)).map(_.length).sum
+      if actualArity != expectedArity then
+        val plural = Option.when(actualArity != 1)("s").getOrElse("")
+        report.errorAndAbort(
+          s"Method ${sym.name} in ${targetType.show} has $actualArity parameter$plural " +
+            s"but received function expects $expectedArity"
+        )
+      if !(returnType <:< methodReturn) then
+        report.errorAndAbort(
+          s"Method ${sym.name} in ${targetType.show} returns ${methodReturn.show} " +
+            s"but received function returns ${returnType.show}"
+        )
+      Some(sym.name)
+
     def findAndCheck(term: Term): Option[String] =
       term match
+        case tapp @ TypeApply(s @ Select(prefix, _), _) if prefix.tpe <:< targetType =>
+          checkAndReturn(s.symbol, finalResultType(tapp.tpe.widen))
         case s @ Select(prefix, _) if prefix.tpe <:< targetType =>
-          val actualArity = s.symbol.paramSymss.filterNot(_.exists(_.isType)).map(_.length).sum
-          if actualArity != expectedArity then
-            val plural = Option.when(actualArity != 1)("s").getOrElse("")
-            report.errorAndAbort(
-              s"Method ${s.symbol.name} in $typeName has $actualArity parameter$plural " +
-                s"but received function expects $expectedArity"
-            )
-          Some(s.symbol.name)
+          checkAndReturn(s.symbol, finalResultType(prefix.tpe.memberType(s.symbol).widen))
         case Lambda(_, body) =>
           findAndCheck(body)
         case Apply(fn, args) =>
@@ -58,4 +79,4 @@ object meta:
       case Some(methodName) =>
         Expr(methodName)
       case None =>
-        report.errorAndAbort(s"Expected selection of a mockable method of $typeName")
+        report.errorAndAbort(s"Expected selection of a mockable method of ${targetType.show}")

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -41,7 +41,7 @@ object meta:
         case _ =>
           t
 
-    def checkAndReturn(sym: Symbol, methodReturn: TypeRepr): Option[String] =
+    def checkAndReturn(sym: Symbol, methodReturn: => TypeRepr): Option[String] =
       val actualArity = sym.paramSymss.filterNot(_.exists(_.isType)).map(_.length).sum
       if actualArity != expectedArity then
         val plural = Option.when(actualArity != 1)("s").getOrElse("")

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -392,31 +392,41 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     assertEquals(repository.times(it.get(_: Boolean)), 1)
 
   test("reject received unrelated expression"):
-    def assertRejects(errors: String) =
+    def assertHasRejection(errors: String) =
       assert(errors.contains("Expected selection of a mockable method"))
 
     // The compiler can't see that this is evaluated below, so silence the warning by forcing it.
     val repository = mock[Repository[User]]
     val _ = repository
 
-    assertRejects(compileErrors("""repository.on((_: String) => true)(_ => true)"""))
-    assertRejects(compileErrors("""repository.times((_: String) => true)"""))
-    assertRejects(compileErrors("""repository.calls((_: String) => true)"""))
-    assertRejects(compileErrors("""repository.forward((_: String) => true, null)"""))
-    assertRejects(compileErrors("""repository.real((_: String) => true)"""))
-    assertRejects(compileErrors("""repository.onCall((_: String) => true)(_ => _ => true)"""))
-    assertRejects(compileErrors("""repository.calledBefore(it.exists, (_: String) => true)"""))
-    assertRejects(compileErrors("""repository.calledAfter(it.exists, (_: String) => true)"""))
+    assertHasRejection(compileErrors("""repository.on((_: String) => true)(_ => true)"""))
+    assertHasRejection(compileErrors("""repository.times((_: String) => true)"""))
+    assertHasRejection(compileErrors("""repository.calls((_: String) => true)"""))
+    assertHasRejection(compileErrors("""repository.forward((_: String) => true, null)"""))
+    assertHasRejection(compileErrors("""repository.real((_: String) => true)"""))
+    assertHasRejection(compileErrors("""repository.onCall((_: String) => true)(_ => _ => true)"""))
+    assertHasRejection(compileErrors("""repository.calledBefore(it.exists, (_: String) => true)"""))
+    assertHasRejection(compileErrors("""repository.calledAfter(it.exists, (_: String) => true)"""))
 
   test("reject unknown received method"):
     given User = mockUsers.head
     val _ = summon[User]
 
-    def assertRejects(errors: String) = assert(errors.contains("received function expects"))
+    def assertHasRejection(errors: String, action: String) =
+      assert(errors.contains(s"received function $action"))
 
-    assertRejects(compileErrors("""mock[Repository[User]].on(it.greet)(_ => "hi!")"""))
-    assertRejects(compileErrors("""mock[Repository[User]].on(it.getNames)(_ => "bdmendes")"""))
-    assertRejects(compileErrors("""mock[Repository[User]].on(() => println(it.get))(_ => ())"""))
+    assertHasRejection(
+      compileErrors("""mock[Repository[User]].on(it.greet)(_ => "hi!")"""),
+      "expects"
+    )
+    assertHasRejection(
+      compileErrors("""mock[Repository[User]].on(it.getNames)(_ => "bdmendes")"""),
+      "expects"
+    )
+    assertHasRejection(
+      compileErrors("""mock[Repository[User]].on(() => println(it.get))(_ => ())"""),
+      "returns"
+    )
 
   test("dispatch a method to a real instance"):
     val mockRepository = mock[Repository[User]].forward(it.exists, realRepository)

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -392,30 +392,31 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     assertEquals(repository.times(it.get(_: Boolean)), 1)
 
   test("reject received unrelated expression"):
-    def assertHasRejection(errors: String) =
+    def assertRejects(errors: String) =
       assert(errors.contains("Expected selection of a mockable method"))
 
     // The compiler can't see that this is evaluated below, so silence the warning by forcing it.
     val repository = mock[Repository[User]]
     val _ = repository
 
-    assertHasRejection(compileErrors("""repository.on((_: String) => true)(_ => true)"""))
-    assertHasRejection(compileErrors("""repository.times((_: String) => true)"""))
-    assertHasRejection(compileErrors("""repository.calls((_: String) => true)"""))
-    assertHasRejection(compileErrors("""repository.forward((_: String) => true, null)"""))
-    assertHasRejection(compileErrors("""repository.real((_: String) => true)"""))
-    assertHasRejection(compileErrors("""repository.onCall((_: String) => true)(_ => _ => true)"""))
-    assertHasRejection(compileErrors("""repository.calledBefore(it.exists, (_: String) => true)"""))
-    assertHasRejection(compileErrors("""repository.calledAfter(it.exists, (_: String) => true)"""))
+    assertRejects(compileErrors("""repository.on((_: String) => true)(_ => true)"""))
+    assertRejects(compileErrors("""repository.times((_: String) => true)"""))
+    assertRejects(compileErrors("""repository.calls((_: String) => true)"""))
+    assertRejects(compileErrors("""repository.forward((_: String) => true, null)"""))
+    assertRejects(compileErrors("""repository.real((_: String) => true)"""))
+    assertRejects(compileErrors("""repository.onCall((_: String) => true)(_ => _ => true)"""))
+    assertRejects(compileErrors("""repository.calledBefore(it.exists, (_: String) => true)"""))
+    assertRejects(compileErrors("""repository.calledAfter(it.exists, (_: String) => true)"""))
 
   test("reject unknown received method"):
     given User = mockUsers.head
     val _ = summon[User]
 
-    def assertHasRejection(errors: String) = assert(errors.contains("received function expects"))
+    def assertRejects(errors: String) = assert(errors.contains("received function expects"))
 
-    assertHasRejection(compileErrors("""mock[Repository[User]].on(it.greet)(_ => "hi!")"""))
-    assertHasRejection(compileErrors("""mock[Repository[User]].on(it.getNames)(_ => "bdmendes")"""))
+    assertRejects(compileErrors("""mock[Repository[User]].on(it.greet)(_ => "hi!")"""))
+    assertRejects(compileErrors("""mock[Repository[User]].on(it.getNames)(_ => "bdmendes")"""))
+    assertRejects(compileErrors("""mock[Repository[User]].on(() => println(it.get))(_ => ())"""))
 
   test("dispatch a method to a real instance"):
     val mockRepository = mock[Repository[User]].forward(it.exists, realRepository)

--- a/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
@@ -31,5 +31,5 @@ private object MetaSpec:
 
   private inline def matchedMethodEntry[T, F[_]](inline expr: Any): String =
     ${
-      matchedMethodName[T, F, Tuple1[?]]('expr)
+      matchedMethodName[T, F, Tuple1[?], Char]('expr)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced method return type validation when matching mocked methods, ensuring selected methods have compatible return types.

* **Tests**
  * Expanded compiler error validation tests to verify correct error messaging for mismatched method signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->