### PR TITLE
Update Scala to 3.9 LTS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,14 +33,11 @@ lazy val root =
           "-encoding",
           "utf8",
           "-deprecation",
-          "-language:implicitConversions",
-          "-Xfatal-warnings",
+          "-Werror",
           "-Wunused:all",
           "-feature",
           "-release",
-          Dependencies.Versions.java,
-          // Workaround for https://github.com/scala/scala3/issues/23967.
-          "-Wconf:origin=scala.compiletime.testing.*:s"
+          Dependencies.Versions.java
         ),
       libraryDependencies ++= Seq(mockito, munit % Test),
       Compile / packageBin / packageOptions +=

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies:
 
   object Versions:
     // We use the latest Scala LTS version, as advised for libraries.
-    lazy val scala = "3.3.8"
+    lazy val scala = "3.9.0-RC1"
     // We want to be conservative with the Java version, but not too much.
     lazy val java = "17"
     lazy val mockito = "5.23.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies:
 
   object Versions:
     // We use the latest Scala LTS version, as advised for libraries.
-    lazy val scala = "3.9.0-RC1"
+    lazy val scala = "3.9.0"
     // We want to be conservative with the Java version, but not too much.
     lazy val java = "17"
     lazy val mockito = "5.23.0"

--- a/src/main/scala/com/bdmendes/smockito/MockedMethod.scala
+++ b/src/main/scala/com/bdmendes/smockito/MockedMethod.scala
@@ -3,7 +3,7 @@ package com.bdmendes.smockito
 /** The internal representation of a method to mock. The compiler synthesizes conversions from
   * regular function types to this type, for up to 22 parameters, via implicit conversions.
   */
-opaque type MockedMethod[A <: Tuple, R] = Pack[A] => R
+into opaque type MockedMethod[A <: Tuple, R] = Pack[A] => R
 
 extension [A <: Tuple, R](mockedMethod: MockedMethod[A, R])
   private inline def tupled: A => R = (args: A) => mockedMethod(pack(args))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Maintenance**
  - Updated the project’s Scala tooling to version 3.9.0.
  - Refined compiler configuration and internal type-conversion declarations for improved compatibility with the updated Scala version.
  - Existing conversion behavior remains unchanged, with no changes to the public API or end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->