### PR TITLE
Return Mock[T] in `it`

### DIFF
--- a/src/main/scala/com/bdmendes/smockito/Smockito.scala
+++ b/src/main/scala/com/bdmendes/smockito/Smockito.scala
@@ -41,7 +41,7 @@ trait Smockito extends MockSyntax:
     * @return
     *   the mock in scope.
     */
-  def it[T](using mock: Mock[T]): T = mock
+  def it[T](using mock: Mock[T]): Mock[T] = mock
 
 object Smockito:
 

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -1,5 +1,6 @@
 package com.bdmendes.smockito.internal
 
+import com.bdmendes.smockito.Mock
 import scala.compiletime.*
 import scala.quoted.*
 import scala.reflect.ClassTag
@@ -20,7 +21,8 @@ object meta:
 
     given Printer[TypeRepr] = Printer.TypeReprShortCode
 
-    val targetType = TypeRepr.of[T]
+    val fTargetType = TypeRepr.of[Mock[T]]
+    val rawTargetType = TypeRepr.of[T]
     val receivedReturnType = TypeRepr.of[R]
     val receivedParamTypes = TypeRepr.of[A].typeArgs
 
@@ -57,9 +59,9 @@ object meta:
         case Apply(_, List(arg)) =>
           // In the case of super class methods such as `toString`, the type argument of `it`
           // widens and so does the resulting expression, so check for an upper bound instead.
-          arg.tpe <:< targetType && targetType <:< term.tpe
+          arg.tpe <:< fTargetType && fTargetType <:< term.tpe
         case _ =>
-          term.tpe <:< targetType
+          term.tpe <:< fTargetType
 
     def showTypes(ts: List[TypeRepr]): String = ts.map(_.show).mkString("(", ", ", ")")
 
@@ -71,12 +73,12 @@ object meta:
       val methodParamTypes = params.map(normalize)
       if !methodParamTypes.corresponds(receivedParamTypes)(isCompatible) then
         report.errorAndAbort(
-          s"Method ${sym.name} in ${targetType.show} expects ${showTypes(methodParamTypes)} " +
+          s"Method ${sym.name} in ${rawTargetType.show} expects ${showTypes(methodParamTypes)} " +
             s"but received function expects ${showTypes(receivedParamTypes.map(normalize))}"
         )
       if !(receivedReturnType <:< methodReturn) then
         report.errorAndAbort(
-          s"Method ${sym.name} in ${targetType.show} returns ${methodReturn.show} " +
+          s"Method ${sym.name} in ${rawTargetType.show} returns ${methodReturn.show} " +
             s"but received function returns ${receivedReturnType.show}"
         )
       Some(sym.name)
@@ -105,4 +107,4 @@ object meta:
       case Some(methodName) =>
         Expr(methodName)
       case None =>
-        report.errorAndAbort(s"Expected selection of a mockable method of ${targetType.show}")
+        report.errorAndAbort(s"Expected selection of a mockable method of ${rawTargetType.show}")

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -1,6 +1,5 @@
 package com.bdmendes.smockito.internal
 
-import com.bdmendes.smockito.Mock
 import scala.compiletime.*
 import scala.quoted.*
 import scala.reflect.ClassTag
@@ -14,14 +13,14 @@ object meta:
       case _: (h *: t) =>
         f[h](using summonInline[ClassTag[h]]) +: mapTuple[t, R](f)
 
-  def matchedMethodName[T: Type, F[_], A <: Tuple: Type, R: Type](expr: Expr[F[T] ?=> Any])(using
-      q: Quotes
+  def matchedMethodName[T: Type, F[_]: Type, A <: Tuple: Type, R: Type](expr: Expr[F[T] ?=> Any])(
+      using q: Quotes
   ): Expr[String] =
     import q.reflect.*
 
     given Printer[TypeRepr] = Printer.TypeReprShortCode
 
-    val fTargetType = TypeRepr.of[Mock[T]]
+    val fTargetType = TypeRepr.of[F[T]]
     val rawTargetType = TypeRepr.of[T]
     val receivedReturnType = TypeRepr.of[R]
     val receivedParamTypes = TypeRepr.of[A].typeArgs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated mock retrieval to return the expected `Mock[T]` value, improving type safety and consistency.
  - Improved method matching for context-function expressions, reducing incorrect selections.
  - Enhanced type-aware diagnostics to provide clearer information when method matching fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->