### PR TITLE
Add regression for extension match

### DIFF
--- a/docs/_docs/guide.md
+++ b/docs/_docs/guide.md
@@ -262,7 +262,13 @@ A reference to the mocked instance itself is available in the stubbing context o
 ```scala
   trait Counter:
     def increment(): Counter
+    def value: Int
 
-  val counter = mock[Counter].on(() => it.increment())(_ => it)
+  val counter =
+    mock[Counter]
+      .on(() => it.increment())(_ => it)
+      .on(() => it.value)(_ => it.times(() => it.increment()))
+
   assert(counter.increment().increment() == counter)
+  assert(counter.value == 2)
 ```

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -397,6 +397,7 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     val repository = mock[Repository[User]]
     val _ = repository
 
+    assertHasRejection(compileErrors("""repository.on(it.calls)(_ => List.empty)"""))
     assertHasRejection(compileErrors("""repository.on((_: String) => true)(_ => true)"""))
     assertHasRejection(compileErrors("""repository.times((_: String) => true)"""))
     assertHasRejection(compileErrors("""repository.calls((_: String) => true)"""))
@@ -746,22 +747,30 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
   test("return self on a stub"):
     trait Counter:
       def increment(): Counter
+      def value: Int
 
-    val counter = mock[Counter].on(() => it.increment())(_ => it)
+    val counter =
+      mock[Counter]
+        .on(() => it.increment())(_ => it)
+        .on(() => it.value)(_ => it.times(() => it.increment()))
 
     assertEquals(counter.increment().increment(), counter)
     assertEquals(counter.times(() => it.increment()), 2)
+    assertEquals(counter.value, 2)
 
   test("return self on an onCall stub"):
     trait Counter:
       def increment(): Counter
+      def value: Int
 
     val counter =
-      mock[Counter].onCall(() => it.increment()): _ =>
-        _ => it
+      mock[Counter]
+        .onCall(() => it.increment())(_ => _ => it)
+        .onCall(() => it.value)(_ => _ => it.times(() => it.increment()))
 
     assertEquals(counter.increment().increment(), counter)
     assertEquals(counter.times(() => it.increment()), 2)
+    assertEquals(counter.value, 2)
 
   test("be resilient to different target names"):
     trait Foo:

--- a/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
@@ -20,6 +20,7 @@ class MetaSpec extends munit.FunSuite:
     assertEquals(matchedMethodEntry[String, Id]((pos: Int) => target.charAt(pos)), "charAt")
 
     assert(hasRejection("matchedMethodEntry[String, Id](0)"))
+    assert(hasRejection("matchedMethodEntry[Int, Id](unrelatedTarget.charAt)"))
     assert(hasRejection("matchedMethodEntry[Int, Id](target.charAt)"))
     assert(hasRejection("matchedMethodEntry[String, Id](() => true)"))
     assert(hasRejection("matchedMethodEntry[String, Id]((_: String) => true)"))
@@ -28,6 +29,7 @@ private object MetaSpec:
   opaque type Id[+T] <: T = T
 
   val target: Id[String] = "Some string"
+  val unrelatedTarget = "Some other string"
 
   private inline def matchedMethodEntry[T, F[_]](inline expr: Any): String =
     ${


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the counter example to expose its current value based on the number of increments.
  * Clarified stubbing syntax for chained calls while preserving fluent increment behavior.

* **Tests**
  * Expanded coverage for value tracking with regular and call-count-based stubbing.
  * Added validation that unrelated methods and targets are rejected during stubbing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->