### PR TITLE
Pin call number reset behavior and document it

### DIFF
--- a/docs/_docs/guide.md
+++ b/docs/_docs/guide.md
@@ -45,12 +45,12 @@ def it[T](using mock: Mock[T]): Mock[T] = mock
 
 ## Method accessor sanity check
 
-Smockito asserts at compile time that received methods are expressions that select a method on the mock type via `it`. This is achieved with a macro that analyzes the abstract syntax tree of the method reference passed to `on`, `calls`, `times` and friends to ensure it conforms to the expected shape. If it doesn't, a compilation error is raised with a helpful message.
+Smockito asserts at compile time that received methods are expressions that directly select a method on the mock type via `it`. This is achieved with a macro that analyzes the abstract syntax tree of the method reference passed to `on`, `calls`, `times` and friends to ensure it conforms to the expected shape. If it doesn't, a compilation error is raised with a helpful message.
 
 ```scala
 |    val repository = mock[Repository[User]].on(unrelated.contains)(_ => true)
 |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-|Expected selection of a mockable method of Repository[User]
+|Expected direct selection of a mockable method of Repository[User]
 ```
 
 Eta-expansion in Scala has its quirks: for instance, it captures any context parameters in scope, rendering a method that effectively does not exist in the JVM bytecode and that Mockito cannot directly mock. Smockito guards against this by rejecting method references whose shape does not match the referenced method in the mocked type, directing the user to eta-expand manually.
@@ -257,7 +257,7 @@ When doing so, consider whether this behavior is a hard requirement of your syst
 
 ## Referencing the Mocked Instance in a Stub
 
-A reference to the mocked instance itself is available in the stubbing context of the `on` and `onCall` methods via `it`.
+A reference to the mocked instance itself is available in the stubbing context of the `on` and `onCall` methods via `it`. Think of `it` as `this` inside a regular class, but for the mock instance.
 
 ```scala
   trait Counter:

--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -84,6 +84,8 @@ private trait MockSyntax:
       *   the stub implementation, based on the received arguments.
       * @return
       *   the mocked type.
+      * @see
+      *   [[onCall]] for the version that also takes the call number into account.
       */
     inline def on[A <: Tuple, R1, R2 <: R1](inline method: Mock[T] ?=> MockedMethod[A, R1])(
         stub: Mock[T] ?=> PartialFunction[Pack[A], R2]
@@ -119,13 +121,14 @@ private trait MockSyntax:
       target.tupled(Tuple.fromArray(meta.mapTuple[A, Any](anyMatcher)).asInstanceOf[A])
       mock
 
-    /** Yields the captured arguments received by a stubbed method, in chronological order. If you
-      * only need to reason about the number of interactions, [[times]] is more efficient.
+    /** Yields the arguments received by a method, per invocation, in chronological order.
       *
       * @param method
       *   the mocked method.
       * @return
       *   the received arguments.
+      * @see
+      *   [[times]] for the version that only counts the number of calls, for efficiency.
       */
     inline def calls[A <: Tuple, R](inline method: Mock[T] ?=> MockedMethod[A, R]): List[Pack[A]] =
       inline erasedValue[A] match
@@ -142,13 +145,14 @@ private trait MockSyntax:
             .toList
             .map(args => pack(Tuple.fromArray(unwrap[A](args)).asInstanceOf[A]))
 
-    /** Yields the number of times a stub was called. If you need the exact arguments, see
-      * [[calls]].
+    /** Yields the number of times a method was called.
       *
       * @param method
       *   the mocked method.
       * @return
-      *   the number of calls to the stub.
+      *   the number of calls to the method.
+      * @see
+      *   [[calls]] if you need the exact received arguments per invocation.
       */
     inline def times[A <: Tuple, R](inline method: Mock[T] ?=> MockedMethod[A, R]): Int =
       validateMethod(method)
@@ -206,15 +210,19 @@ private trait MockSyntax:
       val realMethod = method(using realInstance.asInstanceOf[Mock[T]]).packed
       mock.on(method)(PartialFunctionProxy(realMethod))
 
-    /** Sets up a stub for a method that behaves differently based on the call number. For the
-      * version operating only on the expected set of inputs, see [[on]].
+    /** Sets up a stub for a method that behaves differently based on the call number.
+      *
+      * The call number is local to this stub. If the method is restubbed between calls, it may
+      * differ from the total invocation count reported by [[times]].
       *
       * @param method
       *   the method to mock.
       * @param stub
-      *   the stub implementation, based on the call number of the respective method, starting at 1.
+      *   the stub implementation, based on its call number, starting at 1.
       * @return
       *   the mocked type.
+      * @see
+      *   [[on]] for the version that only considers the expected set of inputs.
       */
     inline def onCall[A <: Tuple, R1, R2 <: R1](inline method: Mock[T] ?=> MockedMethod[A, R1])(
         stub: Mock[T] ?=> PartialFunction[Int, Pack[A] => R2]

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -106,4 +106,6 @@ object meta:
       case Some(methodName) =>
         Expr(methodName)
       case None =>
-        report.errorAndAbort(s"Expected selection of a mockable method of ${rawTargetType.show}")
+        report.errorAndAbort(
+          s"Expected direct selection of a mockable method of ${rawTargetType.show}"
+        )

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -391,7 +391,7 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
 
   test("reject received unrelated expression"):
     def assertHasRejection(errors: String) =
-      assert(errors.contains("Expected selection of a mockable method"))
+      assert(errors.contains("Expected direct selection of a mockable method"))
 
     // The compiler can't see that this is evaluated below, so silence the warning by forcing it.
     val repository = mock[Repository[User]]
@@ -643,6 +643,22 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
 
     intercept[UnexpectedCallNumber]:
       repository.exists("bdmendes")
+
+  test("reset call number count if stub is reconfigured"):
+    trait Counter:
+      def tap: Int
+
+    val counter = mock[Counter].onCall(() => it.tap)(times => _ => times)
+
+    assertEquals(counter.tap, 1)
+    assertEquals(counter.tap, 2)
+
+    counter.onCall(() => it.tap)(times => _ => times * 10)
+
+    assertEquals(counter.tap, 10)
+    assertEquals(counter.tap, 20)
+
+    assertEquals(counter.times(() => it.tap), 4)
 
   test("throw on incompatible received argument type"):
     trait Monitor:

--- a/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
@@ -13,7 +13,7 @@ class MetaSpec extends munit.FunSuite:
 
   test("retrieve matched method name"):
     inline def hasRejection(expr: String): Boolean =
-      compileErrors(expr).contains("Expected selection of a mockable method")
+      compileErrors(expr).contains("Expected direct selection of a mockable method")
 
     assertEquals(matchedMethodEntry[String, Id](target.charAt), "charAt")
     assertEquals(matchedMethodEntry[String, Id](target.charAt(_: Int)), "charAt")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that mocked methods must be selected directly.
  * Documented how `it` is used in stubbing contexts, argument capture, call counts, call numbering, and restubbing behavior.

* **Bug Fixes**
  * Reconfiguring an `onCall` stub now correctly resets its call-number sequence.

* **Tests**
  * Added coverage for `onCall` restubbing and updated validation-message expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->