### PR TITLE
Require reference types; compile under `-source=future`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Codecov](https://img.shields.io/codecov/c/github/bdmendes/smockito/master)](https://app.codecov.io/gh/bdmendes/smockito)
 [![Maven Central](https://img.shields.io/maven-central/v/com.bdmendes/smockito_3)](https://central.sonatype.com/artifact/com.bdmendes/smockito_3/overview)
 
-Smockito is a tiny framework-agnostic Scala 3 facade for [Mockito](https://github.com/mockito/mockito). It enables setting up unique method and value stubs for any type in a type-safe manner, while providing an expressive interface for inspecting received arguments and call counts.
+Smockito is a tiny framework-agnostic Scala 3 facade for [Mockito](https://github.com/mockito/mockito). It enables setting up unique method and value stubs for any reference type in a type-safe manner, while providing an expressive interface for inspecting received arguments and call counts.
 
 Head to the [microsite](https://smockito.bdmendes.com) for the full documentation and API reference.
 

--- a/build.sbt
+++ b/build.sbt
@@ -34,13 +34,11 @@ lazy val root =
           "utf8",
           "-deprecation",
           "-language:implicitConversions",
-          "-Xfatal-warnings",
+          "-Werror",
           "-Wunused:all",
           "-feature",
           "-release",
-          Dependencies.Versions.java,
-          // Workaround for https://github.com/scala/scala3/issues/23967.
-          "-Wconf:origin=scala.compiletime.testing.*:s"
+          Dependencies.Versions.java
         ),
       libraryDependencies ++= Seq(mockito, munit % Test),
       Compile / packageBin / packageOptions +=

--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,8 @@ lazy val root =
           "-language:implicitConversions",
           "-Werror",
           "-Wunused:all",
+          "-source",
+          "future",
           "-feature",
           "-release",
           Dependencies.Versions.java

--- a/docs/_docs/guide.md
+++ b/docs/_docs/guide.md
@@ -40,7 +40,7 @@ Should we have used a regular function type and required `.on(_.compute(_: Int))
 This idea was shamelessly borrowed from Kotlin's [implicit name of a single parameter in lambdas](https://kotlinlang.org/docs/lambdas.html#it-implicit-name-of-a-single-parameter). In the `Smockito` trait, the `it` method is simply defined as:
 
 ```scala
-def it[T](using mock: Mock[T]): Mock[T] = mock
+def it[T <: AnyRef](using mock: Mock[T]): Mock[T] = mock
 ```
 
 ## Method accessor sanity check

--- a/docs/_docs/index.html
+++ b/docs/_docs/index.html
@@ -31,7 +31,7 @@
 
 Smockito is a tiny framework-agnostic Scala 3 facade for
 <a href="https://github.com/mockito/mockito">Mockito</a>. It enables setting up
-unique method and value stubs for any type in a type-safe manner, while
+unique method and value stubs for any reference type in a type-safe manner, while
 providing an expressive interface for inspecting received arguments and call
 counts.
 

--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -16,11 +16,11 @@ import scala.reflect.ClassTag
 /** A `Mock` represents a type mocked by Mockito, with a default answer strategy of throwing on
   * unstubbed methods.
   */
-opaque type Mock[+T] <: T = T
+opaque type Mock[+T <: AnyRef] <: T = T
 
 private trait MockSyntax:
 
-  extension [T](mock: Mock[T])
+  extension [T <: AnyRef](mock: Mock[T])
 
     private inline def validateMethod[A <: Tuple, R](
         inline method: Mock[T] ?=> MockedMethod[A, R]
@@ -29,7 +29,7 @@ private trait MockSyntax:
         meta.matchedMethodName[T, Mock, A, R]('method)
       }
 
-    private inline def unwrap[A](
+    private inline def unwrap[A <: Tuple](
         arguments: Array[Object],
         index: Int = 0,
         needsCloning: Boolean = true
@@ -45,7 +45,7 @@ private trait MockSyntax:
             val unwrapped =
               arguments(index) match
                 case f: Function0[?] =>
-                  inline erasedValue[h] match
+                  inline erasedValue[h & Matchable] match
                     case _: Function0[?] =>
                       f
                     case _ =>
@@ -280,7 +280,7 @@ private object Mock:
       override def apply(args: A): R = f(args)
       override def isDefinedAt(x: A): Boolean = true
 
-  def apply[T](using ct: ClassTag[T]): Mock[T] =
+  def apply[T <: AnyRef](using ct: ClassTag[T]): Mock[T] =
     Mockito.mock(
       ct.runtimeClass.asInstanceOf[Class[T]],
       Mockito.withSettings().defaultAnswer(DefaultAnswer)

--- a/src/main/scala/com/bdmendes/smockito/Smockito.scala
+++ b/src/main/scala/com/bdmendes/smockito/Smockito.scala
@@ -19,7 +19,7 @@ trait Smockito extends MockSyntax:
     * @return
     *   the mock instance.
     */
-  def mock[T: ClassTag]: Mock[T] = Mock.apply
+  def mock[T <: AnyRef: ClassTag]: Mock[T] = Mock.apply
 
   /** Creates a [[Spy]] instance of `T`. A `Spy[T]` is the compile time representation of a real
     * instance of `T` copied by Mockito for spying purposes, erased at runtime.
@@ -29,7 +29,7 @@ trait Smockito extends MockSyntax:
     * @return
     *   the spy instance.
     */
-  def spy[T: ClassTag](realInstance: T): Spy[T] = Spy.apply(realInstance)
+  def spy[T <: AnyRef: ClassTag](realInstance: T): Spy[T] = Spy.apply(realInstance)
 
   /** Retrieves the mock in scope. This is the recommended way to refer to a mock available in
     * context, as is the case when using methods of [[Mock]].
@@ -41,7 +41,7 @@ trait Smockito extends MockSyntax:
     * @return
     *   the mock in scope.
     */
-  def it[T](using mock: Mock[T]): Mock[T] = mock
+  def it[T <: AnyRef](using mock: Mock[T]): Mock[T] = mock
 
 object Smockito:
 

--- a/src/main/scala/com/bdmendes/smockito/Spy.scala
+++ b/src/main/scala/com/bdmendes/smockito/Spy.scala
@@ -9,11 +9,11 @@ import scala.reflect.ClassTag
 /** A `Spy` is a mock whose default answer is to forward all method calls to a real instance, unless
   * stubbed otherwise.
   */
-opaque type Spy[+T] <: Mock[T] = Mock[T]
+opaque type Spy[+T <: AnyRef] <: Mock[T] = Mock[T]
 
 private object Spy:
 
-  def apply[T](realInstance: T)(using ct: ClassTag[T]): Spy[T] =
+  def apply[T <: AnyRef](realInstance: T)(using ct: ClassTag[T]): Spy[T] =
     try
       Mockito.spy(LiftedInstance(realInstance)).asInstanceOf[Mock[T]]
     catch

--- a/src/main/scala/com/bdmendes/smockito/internal/LiftedInstance.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/LiftedInstance.scala
@@ -6,7 +6,7 @@ private[smockito] object LiftedInstance:
 
   // scalafmt: { maxColumn = 240 }
 
-  def apply[T](obj: T)(using ct: ClassTag[T]): T =
+  def apply[T <: AnyRef](obj: T)(using ct: ClassTag[T]): T =
     val proxy =
       obj match
         // Lambdas require special treatment as they are usually synthetic classes

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -13,9 +13,9 @@ object meta:
       case _: (h *: t) =>
         f[h](using summonInline[ClassTag[h]]) +: mapTuple[t, R](f)
 
-  def matchedMethodName[T: Type, F[_]: Type, A <: Tuple: Type, R: Type](expr: Expr[F[T] ?=> Any])(
-      using q: Quotes
-  ): Expr[String] =
+  def matchedMethodName[T <: AnyRef: Type, F[_ <: AnyRef]: Type, A <: Tuple: Type, R: Type](
+      expr: Expr[F[T] ?=> Any]
+  )(using q: Quotes): Expr[String] =
     import q.reflect.*
 
     given Printer[TypeRepr] = Printer.TypeReprShortCode
@@ -28,7 +28,7 @@ object meta:
     def methodSignature(t: TypeRepr): (List[TypeRepr], TypeRepr) =
       // Concatenate the parameter lists into a single one, as one needs to do
       // in manual eta-expansion for curried methods.
-      t match
+      t.asMatchable match
         case MethodType(_, params, ret) =>
           val (retParams, result) = methodSignature(ret)
           (params ++ retParams, result)
@@ -38,14 +38,14 @@ object meta:
 
     def normalize(t: TypeRepr): TypeRepr =
       // Desugar for varargs, compiled to a Seq.
-      t.widenTermRefByName.widenByName match
+      t.widenTermRefByName.widenByName.asMatchable match
         case AppliedType(tycon, arg :: Nil) if tycon.typeSymbol == defn.RepeatedParamClass =>
           TypeRepr.of[Seq].appliedTo(arg)
         case t =>
           t
 
     def isCompatible(actual: TypeRepr, expected: TypeRepr): Boolean =
-      expected.dealias match
+      expected.dealias.asMatchable match
         case TypeBounds(low, high) =>
           normalize(low) <:< actual && actual <:< normalize(high)
         case expected =>

--- a/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
@@ -31,7 +31,7 @@ private object MetaSpec:
   val target: Id[String] = "Some string"
   val unrelatedTarget = "Some other string"
 
-  private inline def matchedMethodEntry[T, F[_]](inline expr: Any): String =
+  private inline def matchedMethodEntry[T <: AnyRef, F[_ <: AnyRef]](inline expr: Any): String =
     ${
       matchedMethodName[T, F, Tuple1[?], Char]('expr)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Mock and spy APIs now support reference types only; primitive and value types can no longer be used as mock or spy targets.
  * Updated type matching to improve compatibility with Scala’s type system.

* **Documentation**
  * Clarified that stubs reference supported types rather than arbitrary values.

* **Build Improvements**
  * Updated compiler warning and source compatibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->