### PR TITLE
Fix side effects of mismatched nullary function args

### DIFF
--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -4,6 +4,7 @@ import Mock.mapper.*
 import com.bdmendes.smockito.Smockito.SmockitoException.*
 import com.bdmendes.smockito.internal.DefaultAnswer
 import com.bdmendes.smockito.internal.meta
+import com.bdmendes.smockito.internal.meta.MethodParameterType
 import java.lang.reflect.Method
 import java.util.concurrent.atomic.AtomicInteger
 import org.mockito.*
@@ -22,21 +23,22 @@ private trait MockSyntax:
 
   extension [T <: AnyRef](mock: Mock[T])
 
-    private inline def validateMethod[A <: Tuple, R](
+    private inline def validateAndRetrieveMethodInfo[A <: Tuple, R](
         inline method: Mock[T] ?=> MockedMethod[A, R]
-    ): Unit =
+    ): (String, Array[meta.MethodParameterType]) =
       ${
-        meta.matchedMethodName[T, Mock, A, R]('method)
+        meta.matchedMethodInfo[T, Mock, A, R]('method)
       }
 
     private inline def unwrap[A <: Tuple](
         arguments: Array[Object],
+        parameterTypes: Array[meta.MethodParameterType],
         index: Int = 0,
         needsCloning: Boolean = true
     ): Array[Object] =
       // By-name parameters are compiled as nullary functions, hence the special treatment.
       if needsCloning then
-        unwrap[A](arguments.clone(), index, false)
+        unwrap[A](arguments.clone(), parameterTypes, index, false)
       else
         inline erasedValue[A] match
           case _: EmptyTuple =>
@@ -45,11 +47,11 @@ private trait MockSyntax:
             val unwrapped =
               arguments(index) match
                 case f: Function0[?] =>
-                  inline erasedValue[h & Matchable] match
-                    case _: Function0[?] =>
-                      f
-                    case _ =>
+                  parameterTypes(index) match
+                    case MethodParameterType.ByName(_) =>
                       f.apply()
+                    case MethodParameterType.Regular(_) =>
+                      f
                 case other =>
                   other
             val typeCheckedValue =
@@ -63,7 +65,7 @@ private trait MockSyntax:
               else
                 unwrapped
             arguments.update(index, typeCheckedValue.asInstanceOf[Object])
-            unwrap[t](arguments, index + 1, false)
+            unwrap[t](arguments, parameterTypes, index + 1, false)
 
     private inline def verifies(f: => Any): Boolean =
       // Sometimes we need to resort to Mockito verifications with mode different than `atLeast(0)`.
@@ -93,13 +95,13 @@ private trait MockSyntax:
     inline def onCall[A <: Tuple, R1, R2 <: R1](inline method: Mock[T] ?=> MockedMethod[A, R1])(
         stub: Mock[T] ?=> PartialFunction[Int, PartialFunction[Pack[A], R2]]
     ): Mock[T] =
-      validateMethod(method)
+      val (_, parameterTypes) = validateAndRetrieveMethodInfo(method)
       val callCount = AtomicInteger(0)
       val answer: Answer[R2] =
         invocation =>
           val call = callCount.incrementAndGet()
           val f = stub(using mock).applyOrElse(call, _ => throw UnexpectedCallNumber(call))
-          val arguments = unwrap[A](invocation.getRawArguments)
+          val arguments = unwrap[A](invocation.getRawArguments, parameterTypes)
           f.applyOrElse(
             pack(Tuple.fromArray(arguments).asInstanceOf[A]),
             _ => throw UnexpectedArguments(invocation.getMethod, arguments)
@@ -138,7 +140,7 @@ private trait MockSyntax:
       *   the mocked type.
       */
     inline def real[A <: Tuple, R](inline method: Mock[T] ?=> MockedMethod[A, R]): Mock[T] =
-      validateMethod(method)
+      val _ = validateAndRetrieveMethodInfo(method)
       val target = method(using Mockito.doCallRealMethod().when(mock))
       target.tupled(Tuple.fromArray(meta.mapTuple[A, Any](anyMatcher)).asInstanceOf[A])
       mock
@@ -157,7 +159,7 @@ private trait MockSyntax:
         case _: EmptyTuple =>
           error("`calls` is not available for nullary methods; use `times` instead")
         case _ =>
-          validateMethod(method)
+          val (_, parameterTypes) = validateAndRetrieveMethodInfo(method)
           val argCaptors = meta.mapTuple[A, ArgumentCaptor[?]](captor)
           val target = method(using Mockito.verify(mock, Mockito.atLeast(0)))
           target.tupled(Tuple.fromArray(argCaptors.map(_.capture())).asInstanceOf[A])
@@ -165,7 +167,7 @@ private trait MockSyntax:
             .map(_.getAllValues.toArray)
             .transpose
             .toList
-            .map(args => pack(Tuple.fromArray(unwrap[A](args)).asInstanceOf[A]))
+            .map(args => pack(Tuple.fromArray(unwrap[A](args, parameterTypes)).asInstanceOf[A]))
 
     /** Yields the number of times a method was called.
       *
@@ -177,7 +179,7 @@ private trait MockSyntax:
       *   [[calls]] if you need the exact received arguments per invocation.
       */
     inline def times[A <: Tuple, R](inline method: Mock[T] ?=> MockedMethod[A, R]): Int =
-      validateMethod(method)
+      val _ = validateAndRetrieveMethodInfo(method)
       inline erasedValue[A] match
         case _: EmptyTuple =>
           // Mockito has no reliable API for this use case, so we have to resort to inspecting the
@@ -246,8 +248,8 @@ private trait MockSyntax:
         inline a: Mock[T] ?=> MockedMethod[A1, R1],
         inline b: Mock[T] ?=> MockedMethod[A2, R2]
     ): Boolean =
-      validateMethod(a)
-      validateMethod(b)
+      val _ = validateAndRetrieveMethodInfo(a)
+      val _ = validateAndRetrieveMethodInfo(b)
       val ordered = Mockito.inOrder(mock)
       verifies:
         val targetA = a(using ordered.verify(mock, Mockito.atLeastOnce))

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -6,6 +6,10 @@ import scala.reflect.ClassTag
 
 object meta:
 
+  enum MethodParameterType:
+    case ByName(tp: Class[?])
+    case Regular(tp: Class[?])
+
   inline def mapTuple[T <: Tuple, R: ClassTag](inline f: [X] => (ClassTag[X]) ?=> R): Array[R] =
     inline erasedValue[T] match
       case _: EmptyTuple =>
@@ -13,9 +17,9 @@ object meta:
       case _: (h *: t) =>
         f[h](using summonInline[ClassTag[h]]) +: mapTuple[t, R](f)
 
-  def matchedMethodName[T <: AnyRef: Type, F[_ <: AnyRef]: Type, A <: Tuple: Type, R: Type](
+  def matchedMethodInfo[T <: AnyRef: Type, F[_ <: AnyRef]: Type, A <: Tuple: Type, R: Type](
       expr: Expr[F[T] ?=> Any]
-  )(using q: Quotes): Expr[String] =
+  )(using q: Quotes): Expr[(String, Array[MethodParameterType])] =
     import q.reflect.*
 
     given Printer[TypeRepr] = Printer.TypeReprShortCode
@@ -64,7 +68,7 @@ object meta:
 
     def showTypes(ts: List[TypeRepr]): String = ts.map(_.show).mkString("(", ", ", ")")
 
-    def checkAndReturn(sym: Symbol, methodType: TypeRepr): Option[String] =
+    def checkAndReturn(sym: Symbol, methodType: TypeRepr): Option[(String, List[TypeRepr])] =
       // Eta-expansion in Scala has its quirks, such as capturing contextual arguments,
       // effectively returning a function whose shape does not exist in the class byte code.
       // This hints the user to eta-expand manually at compile time.
@@ -80,9 +84,9 @@ object meta:
           s"Method ${sym.name} in ${rawTargetType.show} returns ${methodReturn.show} " +
             s"but received function returns ${receivedReturnType.show}"
         )
-      Some(sym.name)
+      Some((sym.name, params))
 
-    def findAndCheck(term: Term): Option[String] =
+    def findAndCheck(term: Term): Option[(String, List[TypeRepr])] =
       term match
         // Method selection.
         case tapp @ TypeApply(s @ Select(prefix, _), _) if targetsType(prefix) =>
@@ -103,8 +107,36 @@ object meta:
           None
 
     findAndCheck(expr.asTerm) match
-      case Some(methodName) =>
-        Expr(methodName)
+      case Some((methodName, parameterTypes)) =>
+        val parameterTypeExprs =
+          parameterTypes.map: parameterType =>
+            val runtimeClass =
+              normalize(parameterType).asType match
+                case '[parameterType] =>
+                  '{
+                    summonInline[ClassTag[parameterType]].runtimeClass
+                  }
+            parameterType match
+              case _: ByNameType =>
+                '{
+                  MethodParameterType.ByName($runtimeClass)
+                }
+              case _ =>
+                '{
+                  MethodParameterType.Regular($runtimeClass)
+                }
+        '{
+          (
+            ${
+              Expr(methodName)
+            },
+            Array[MethodParameterType](
+              ${
+                Varargs(parameterTypeExprs)
+              }*
+            )
+          )
+        }
       case None =>
         report.errorAndAbort(
           s"Expected direct selection of a mockable method of ${rawTargetType.show}"

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -163,6 +163,14 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     assert(repository.hasCount(0))
     assert(!repository.hasCount(1))
 
+  test("set up method stubs on by-name parameters containing nullary functions"):
+    trait Foo:
+      def call(f: => () => Int): Int
+
+    val foo = mock[Foo].on(it.call(_: (() => Int)))(f => f())
+
+    assertEquals(foo.call(() => 1), 1)
+
   test("set up method stubs on methods with variable arguments"):
     val repository =
       mock[Repository[User]].on(it.containsOneOf(_*)): names =>
@@ -826,6 +834,15 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
       final def bar = 0
     val m = mock[Foo].on(() => it.bar)(_ => 1)
     assertEquals(m.bar, 1)
+
+  test("not call a thunk as a side effect of stubbing against a super type"):
+    trait Foo:
+      def bar(a: Any): Int
+
+    var counter = 0
+    val foo = mock[Foo].on(it.bar)(f => 0)
+    assertEquals(foo.bar(() => counter += 1), 0)
+    assertEquals(counter, 0)
 
 object SmockitoSpec:
 

--- a/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
@@ -15,9 +15,9 @@ class MetaSpec extends munit.FunSuite:
     inline def hasRejection(expr: String): Boolean =
       compileErrors(expr).contains("Expected direct selection of a mockable method")
 
-    assertEquals(matchedMethodEntry[String, Id](target.charAt), "charAt")
-    assertEquals(matchedMethodEntry[String, Id](target.charAt(_: Int)), "charAt")
-    assertEquals(matchedMethodEntry[String, Id]((pos: Int) => target.charAt(pos)), "charAt")
+    assertEquals(matchedMethodEntry[String, Id](target.charAt)._1, "charAt")
+    assertEquals(matchedMethodEntry[String, Id](target.charAt(_: Int))._1, "charAt")
+    assertEquals(matchedMethodEntry[String, Id]((pos: Int) => target.charAt(pos))._1, "charAt")
 
     assert(hasRejection("matchedMethodEntry[String, Id](0)"))
     assert(hasRejection("matchedMethodEntry[Int, Id](unrelatedTarget.charAt)"))
@@ -31,7 +31,9 @@ private object MetaSpec:
   val target: Id[String] = "Some string"
   val unrelatedTarget = "Some other string"
 
-  private inline def matchedMethodEntry[T <: AnyRef, F[_ <: AnyRef]](inline expr: Any): String =
+  private inline def matchedMethodEntry[T <: AnyRef, F[_ <: AnyRef]](
+      inline expr: Any
+  ): (String, Array[?]) =
     ${
-      matchedMethodName[T, F, Tuple1[?], Char]('expr)
+      matchedMethodInfo[T, F, Tuple1[?], Char]('expr)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of methods with by-name parameters during mocking.
  * Prevented thunk arguments from being evaluated unexpectedly when stubbing methods that accept general values.
  * Ensured deferred function arguments are invoked only when the mocked response is executed.

* **Tests**
  * Added regression coverage for by-name parameters, nullary functions, and side-effect-free stubbing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->