### PR TITLE
Test and document disallowed primitive mocking

### DIFF
--- a/docs/_docs/faq.md
+++ b/docs/_docs/faq.md
@@ -2,6 +2,10 @@
 
 No. Smockito leverages a handful of powerful Scala 3 features, such as inlining, opaque types, context functions and match types. If you are on the process of migrating a Scala 2 codebase, it might be a good opportunity to replace the likes of [specs2-mock](https://mvnrepository.com/artifact/org.specs2/specs2-mock) or [mockito-scala](https://github.com/mockito/mockito-scala) as you migrate your modules.
 
+# How thread-safe is Smockito?
+
+The same as Mockito, which does some effort to synchronize access to its internal state, e.g. whilst tracking calls. However, the most reliable way to ensure consistency is to avoid sharing mocks across threads.
+
 # Is this really a mocking framework?
 
 This is a [facade](https://en.m.wikipedia.org/wiki/Facade_pattern) for Mockito, which in itself is technically a [test spy framework](https://github.com/mockito/mockito/wiki/FAQ#is-it-really-a-mocking-framework). There is a great debate regarding the definitions of mocks, stubs, spies, test duplicates... Here, we assume a mock to be a "faked" object, and a stub a provided implementation for a subset of the input space.

--- a/docs/_docs/faq.md
+++ b/docs/_docs/faq.md
@@ -4,7 +4,7 @@ No. Smockito leverages a handful of powerful Scala 3 features, such as inlining,
 
 # How thread-safe is Smockito?
 
-The same as Mockito, which does some effort to synchronize access to its internal state, e.g. whilst tracking calls. However, the most reliable way to ensure consistency is to avoid sharing mocks across threads.
+The same as Mockito, which supports tracking concurrent calls to an already-configured shared mock, but not concurrent stubbing or verification.
 
 # Is this really a mocking framework?
 

--- a/docs/_docs/guide.md
+++ b/docs/_docs/guide.md
@@ -168,6 +168,28 @@ def mockExecutor(returnValue: Int): Mock[Executor] =
 
 That said, if you really need to override a stub, you may do so by calling `on` again for the same method. The last stub takes precedence.
 
+## Mocking Non-Reference Types
+
+A Smockito `Mock` has an upper bound of `AnyRef`, which means that Smockito cannot mock complex, erased Scala types as unions, intersections and opaque types, nor primitive types such as `Int`. The reason for this is the underlying desugaring to Mockito, which needs to modify methods on JVM types that are actual classes at runtime; in the same vein, extension methods, that are actually not a part of the type they extend, also cannot be mocked.
+
+A simple solution is to depend on some interface instead and have your complex type implement it for the production path. For instance, if you have
+
+```scala
+opaque type UserId = String
+```
+
+You could design the implementations with typeclasses instead of extension methods, and have your dependant require a `Name[UserId]` or even a `Name[T]` for any `T`.
+
+```scala
+trait Name[+A]:
+  def name(x: A): String
+
+given Name[UserId]:
+  def name(x: UserId): String = x
+```
+
+For unions, mocking one of the alternatives usually suffices.
+
 ## Mocking Objects
 
 A Scala `object` is a type with a singleton instance. If you explicitly require it as a dependency and program against it, you may mock it like any other class. For instance, if you have:

--- a/docs/_docs/guide.md
+++ b/docs/_docs/guide.md
@@ -181,7 +181,7 @@ opaque type UserId = String
 You could design the implementations with typeclasses instead of extension methods, and have your dependant require a `Name[UserId]` or even a `Name[T]` for any `T`.
 
 ```scala
-trait Name[+A]:
+trait Name[A]:
   def name(x: A): String
 
 given Name[UserId]:

--- a/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/SmockitoSpec.scala
@@ -844,6 +844,27 @@ class SmockitoSpec extends munit.FunSuite with Smockito:
     assertEquals(foo.bar(() => counter += 1), 0)
     assertEquals(counter, 0)
 
+  test("disallow mocking non reference types"):
+    object Outer:
+      opaque type SpookyUser = User
+      extension (u: SpookyUser)
+        def pretty = "yes"
+        def toUser: User = u
+
+    def assertDoesNotConform(errors: String) =
+      assert(errors.contains("does not conform to upper bound AnyRef"), errors)
+
+    assertDoesNotConform(compileErrors("""mock[Outer.SpookyUser]"""))
+    assertDoesNotConform(compileErrors("""mock[String | Outer.SpookyUser]"""))
+    assertDoesNotConform(compileErrors("""mock[Long]"""))
+    assertDoesNotConform(compileErrors("""mock[Int]"""))
+
+    // Of course, with inside knowledge, we can tricky the compiler into mocking opaque types.
+    // This should be used as a last resort; depend on an interface instead.
+    val spooky = mock[User].on(() => it.username)(_ => "tampered").asInstanceOf[Outer.SpookyUser]
+    assertEquals(spooky.pretty, "yes")
+    assertEquals(spooky.toUser.username, "tampered")
+
 object SmockitoSpec:
 
   abstract class Repository[T](val name: String):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added FAQ guidance on thread safety, including recommendations for using mocks across threads.
  * Documented limitations when mocking primitives, opaque types, unions, intersections, and extension methods.
  * Added recommended alternatives, such as interfaces and typeclasses, for unsupported types.

* **Tests**
  * Added coverage confirming unsupported mock types are rejected and compatible opaque-type usage behaves as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->