### PR TITLE
Remove unused runtime classes; surface first class `MatchedMethodInfo`

### DIFF
--- a/src/main/scala/com/bdmendes/smockito/Mock.scala
+++ b/src/main/scala/com/bdmendes/smockito/Mock.scala
@@ -24,14 +24,14 @@ private trait MockSyntax:
 
     private inline def validateAndRetrieveMethodInfo[A <: Tuple, R](
         inline method: Mock[T] ?=> MockedMethod[A, R]
-    ): (String, Array[meta.MethodParameterType]) =
+    ): meta.MatchedMethodInfo =
       ${
         meta.matchedMethodInfo[T, Mock, A, R]('method)
       }
 
     private inline def unwrap[A <: Tuple](
         arguments: Array[Object],
-        parameterTypes: Array[meta.MethodParameterType],
+        parameterTypes: IndexedSeq[meta.MethodParameterType],
         index: Int = 0,
         needsCloning: Boolean = true
     ): Array[Object] =
@@ -47,9 +47,9 @@ private trait MockSyntax:
               arguments(index) match
                 case f: Function0[?] =>
                   parameterTypes(index) match
-                    case meta.MethodParameterType.ByName(_) =>
+                    case meta.MethodParameterType.ByName =>
                       f.apply()
-                    case meta.MethodParameterType.Regular(_) =>
+                    case meta.MethodParameterType.Regular =>
                       f
                 case other =>
                   other
@@ -94,13 +94,13 @@ private trait MockSyntax:
     inline def onCall[A <: Tuple, R1, R2 <: R1](inline method: Mock[T] ?=> MockedMethod[A, R1])(
         stub: Mock[T] ?=> PartialFunction[Int, PartialFunction[Pack[A], R2]]
     ): Mock[T] =
-      val (_, parameterTypes) = validateAndRetrieveMethodInfo(method)
+      val info = validateAndRetrieveMethodInfo(method)
       val callCount = AtomicInteger(0)
       val answer: Answer[R2] =
         invocation =>
           val call = callCount.incrementAndGet()
           val f = stub(using mock).applyOrElse(call, _ => throw UnexpectedCallNumber(call))
-          val arguments = unwrap[A](invocation.getRawArguments, parameterTypes)
+          val arguments = unwrap[A](invocation.getRawArguments, info.parameterTypes)
           f.applyOrElse(
             pack(Tuple.fromArray(arguments).asInstanceOf[A]),
             _ => throw UnexpectedArguments(invocation.getMethod, arguments)
@@ -158,7 +158,7 @@ private trait MockSyntax:
         case _: EmptyTuple =>
           error("`calls` is not available for nullary methods; use `times` instead")
         case _ =>
-          val (_, parameterTypes) = validateAndRetrieveMethodInfo(method)
+          val info = validateAndRetrieveMethodInfo(method)
           val argCaptors = meta.mapTuple[A, ArgumentCaptor[?]](captor)
           val target = method(using Mockito.verify(mock, Mockito.atLeast(0)))
           target.tupled(Tuple.fromArray(argCaptors.map(_.capture())).asInstanceOf[A])
@@ -166,7 +166,9 @@ private trait MockSyntax:
             .map(_.getAllValues.toArray)
             .transpose
             .toList
-            .map(args => pack(Tuple.fromArray(unwrap[A](args, parameterTypes)).asInstanceOf[A]))
+            .map(args =>
+              pack(Tuple.fromArray(unwrap[A](args, info.parameterTypes)).asInstanceOf[A])
+            )
 
     /** Yields the number of times a method was called.
       *

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -7,8 +7,10 @@ import scala.reflect.ClassTag
 object meta:
 
   enum MethodParameterType:
-    case ByName(tp: Class[?])
-    case Regular(tp: Class[?])
+    case ByName
+    case Regular
+
+  type MatchedMethodInfo = (name: String, parameterTypes: IndexedSeq[MethodParameterType])
 
   inline def mapTuple[T <: Tuple, R: ClassTag](inline f: [X] => (ClassTag[X]) ?=> R): Array[R] =
     inline erasedValue[T] match
@@ -19,7 +21,7 @@ object meta:
 
   def matchedMethodInfo[T <: AnyRef: Type, F[_ <: AnyRef]: Type, A <: Tuple: Type, R: Type](
       expr: Expr[F[T] ?=> Any]
-  )(using q: Quotes): Expr[(String, Array[MethodParameterType])] =
+  )(using q: Quotes): Expr[MatchedMethodInfo] =
     import q.reflect.*
 
     given Printer[TypeRepr] = Printer.TypeReprShortCode
@@ -114,27 +116,21 @@ object meta:
       case Some((methodName, parameterTypes)) =>
         val parameterTypeExprs =
           parameterTypes.map: parameterType =>
-            val runtimeClass =
-              normalize(parameterType).asType match
-                case '[parameterType] =>
-                  '{
-                    summonInline[ClassTag[parameterType]].runtimeClass
-                  }
             parameterType match
               case _: ByNameType =>
                 '{
-                  MethodParameterType.ByName($runtimeClass)
+                  MethodParameterType.ByName
                 }
               case _ =>
                 '{
-                  MethodParameterType.Regular($runtimeClass)
+                  MethodParameterType.Regular
                 }
         '{
           (
             ${
               Expr(methodName)
             },
-            Array[MethodParameterType](
+            IndexedSeq[MethodParameterType](
               ${
                 Varargs(parameterTypeExprs)
               }*

--- a/src/main/scala/com/bdmendes/smockito/internal/meta.scala
+++ b/src/main/scala/com/bdmendes/smockito/internal/meta.scala
@@ -115,22 +115,21 @@ object meta:
     findAndCheck(expr.asTerm) match
       case Some((methodName, parameterTypes)) =>
         val parameterTypeExprs =
-          parameterTypes.map: parameterType =>
-            parameterType match
-              case _: ByNameType =>
-                '{
-                  MethodParameterType.ByName
-                }
-              case _ =>
-                '{
-                  MethodParameterType.Regular
-                }
+          parameterTypes.map:
+            case _: ByNameType =>
+              '{
+                MethodParameterType.ByName
+              }
+            case _ =>
+              '{
+                MethodParameterType.Regular
+              }
         '{
           (
             ${
               Expr(methodName)
             },
-            IndexedSeq[MethodParameterType](
+            IndexedSeq(
               ${
                 Varargs(parameterTypeExprs)
               }*

--- a/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
+++ b/src/test/scala/com/bdmendes/smockito/internal/MetaSpec.scala
@@ -15,9 +15,9 @@ class MetaSpec extends munit.FunSuite:
     inline def hasRejection(expr: String): Boolean =
       compileErrors(expr).contains("Expected direct selection of a mockable method")
 
-    assertEquals(matchedMethodEntry[String, Id](target.charAt)._1, "charAt")
-    assertEquals(matchedMethodEntry[String, Id](target.charAt(_: Int))._1, "charAt")
-    assertEquals(matchedMethodEntry[String, Id]((pos: Int) => target.charAt(pos))._1, "charAt")
+    assertEquals(matchedMethodEntry[String, Id](target.charAt).name, "charAt")
+    assertEquals(matchedMethodEntry[String, Id](target.charAt(_: Int)).name, "charAt")
+    assertEquals(matchedMethodEntry[String, Id]((pos: Int) => target.charAt(pos)).name, "charAt")
 
     assert(hasRejection("matchedMethodEntry[String, Id](0)"))
     assert(hasRejection("matchedMethodEntry[Int, Id](unrelatedTarget.charAt)"))
@@ -33,7 +33,7 @@ private object MetaSpec:
 
   private inline def matchedMethodEntry[T <: AnyRef, F[_ <: AnyRef]](
       inline expr: Any
-  ): (String, Array[?]) =
+  ): MatchedMethodInfo =
     ${
       matchedMethodInfo[T, F, Tuple1[?], Char]('expr)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal method matching and call handling for more consistent parameter processing.
  - Updated internal metadata representation to simplify method information tracking.
  - No user-facing behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->